### PR TITLE
feat(io): support for setting the initial storage from external source

### DIFF
--- a/.changeset/clever-pets-marry.md
+++ b/.changeset/clever-pets-marry.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": minor
+---
+
+Added `initialStorage` param to `createIO` to set initialStorage state of room.

--- a/.changeset/neat-dodos-jump.md
+++ b/.changeset/neat-dodos-jump.md
@@ -1,0 +1,5 @@
+---
+"@pluv/client": patch
+---
+
+Omitted unused `encodedState` param from PluvRoom.

--- a/packages/client/src/CrdtManager.ts
+++ b/packages/client/src/CrdtManager.ts
@@ -5,7 +5,7 @@ import type { AbstractType } from "yjs";
 export interface CrdtManagerOptions<
     TStorage extends Record<string, AbstractType<any>> = {}
 > {
-    encodedState?: string | Uint8Array;
+    encodedState?: string | Uint8Array | null;
     initialStorage?: () => TStorage;
 }
 

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -105,7 +105,7 @@ export type PluvRoomOptions<
 > = {
     debug?: boolean | PluvRoomDebug<TIO>;
     onAuthorizationFail?: (error: Error) => void;
-} & CrdtManagerOptions<TStorage> &
+} & Omit<CrdtManagerOptions<TStorage>, "encodedState"> &
     UsersManagerConfig<TPresence>;
 
 export type RoomConfig<

--- a/packages/io/src/createIO.ts
+++ b/packages/io/src/createIO.ts
@@ -4,6 +4,8 @@ import type {
     BaseUser,
     IOAuthorize,
     JsonObject,
+    Maybe,
+    MaybePromise,
 } from "@pluv/types";
 import type { AbstractPlatform } from "./AbstractPlatform";
 import { PluvIO } from "./PluvIO";
@@ -17,6 +19,7 @@ export interface CreateIOParams<
     authorize?: IOAuthorize<TAuthorizeUser, TAuthorizeRequired>;
     context?: TContext;
     debug?: boolean;
+    initialStorage?: (room: string) => MaybePromise<Maybe<string>>;
     platform: TPlatform;
 }
 
@@ -39,7 +42,7 @@ export const createIO = <
     BaseClientEventRecord,
     BaseIOEventRecord<IOAuthorize<TAuthorizeUser, TAuthorizeRequired>>
 > => {
-    const { authorize, context, debug, platform } = params;
+    const { authorize, context, debug, initialStorage, platform } = params;
 
     return new PluvIO<
         TPlatform,
@@ -47,5 +50,5 @@ export const createIO = <
         TContext,
         BaseClientEventRecord,
         BaseIOEventRecord<IOAuthorize<TAuthorizeUser, TAuthorizeRequired>>
-    >({ authorize, context, debug, platform });
+    >({ authorize, context, debug, initialStorage, platform });
 };


### PR DESCRIPTION
Closes #<issue>

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] I have added or updated the tests related to the changes made.

---

## Changelog

* Added support for setting the initial storage state of the IORoom from external storage sources (e.g. databases).