### PR TITLE
ci: exclude renovate in auto-assign workflow

### DIFF
--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -14,4 +14,4 @@ numberOfReviewers: 0
 
 # A list of keywords to be skipped the process if PR's title include it
 skipKeywords:
-  - wip
+  - renovate, wip


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] I have added or updated the tests related to the changes made.

---

## Changelog

Exclude renovate from auto-assign workflow.