### PR TITLE
chore: update renovate to not be auto-assigned in pull requests

### DIFF
--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -14,4 +14,7 @@ numberOfReviewers: 0
 
 # A list of keywords to be skipped the process if PR's title include it
 skipKeywords:
-  - renovate, wip
+  - draft, wip
+
+excludeLabels:
+  - renovate

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":preserveSemverRanges"],
+  "labels": ["renovate"],
   "updateInternalDeps": true,
   "packageRules": [
     {


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] I have added or updated the tests related to the changes made.

---

## Changelog

Updated renovate and auto-assign so that renovate bot isn't auto-assigned in pull requests.