### PR TITLE
chore(crdt-yjs): added support for remaining yjs shared types

### DIFF
--- a/.changeset/hip-flies-float.md
+++ b/.changeset/hip-flies-float.md
@@ -1,0 +1,5 @@
+---
+"@pluv/crdt-yjs": minor
+---
+
+Added support for yjs xml types including XmlElement, XmlFragment and XmlText

--- a/docs/crdt-storage.md
+++ b/docs/crdt-storage.md
@@ -6,8 +6,8 @@ Pluv.IO uses [yjs](https://yjs.dev/) to enable easy shared data manipulation bet
 
 Install yjs
 
-> **Note**
-> Yjs is a peer dependency of pluv packages, so make sure to install wherever the server and/or client are located (in both places if these are separate). This is currently necessary even if you are not using yjs in your setup.
+> **Note:**
+> Yjs is a peer dependency of pluv packages, so make sure to install `yjs` wherever the server and/or client are located (in both places if these are separate). This is currently necessary even if you are not using yjs in your project.
 
 ```bash
 $ npm install yjs

--- a/packages/crdt-yjs/README.md
+++ b/packages/crdt-yjs/README.md
@@ -54,6 +54,11 @@ pnpm add @pluv/crdt-yjs yjs
 
 ```ts
 import { createClient, y } from "@pluv/client";
+import type {
+    Array as YArray,
+    Map as YMap,
+    XmlFragment as YXmlFragment,
+} from "yjs";
 import { z } from "zod";
 // Import the PluvIO instance as a type from your server file
 import { type io } from "./server";
@@ -63,13 +68,21 @@ const client = createClient<typeof io>({ /* client config here */ });
 type Presence = {};
 
 interface Storage {
-    groceryList: { [food: string]: number };
-    messages: readonly { name: string; message: string }[]
+    editor: YXmlFragment;
+    groceryList: YMap<string, number>;
+    messages: YArray<{ name: string; message: string }>;
 }
 
 // Create a room to join
 const room = client.createRoom<Presence, Storage>("my-room", {
     initialStorage: () => ({
+        editor: y.xmlFragment({
+            children: [
+                y.xmlElement("paragraph", {
+                  children: [y.xmlText("Hello World!")],
+                }),
+            ]
+        }),
         groceryList: y.map([
             ["apricots", 2],
             ["bread", 3],

--- a/packages/crdt-yjs/src/doc.ts
+++ b/packages/crdt-yjs/src/doc.ts
@@ -1,7 +1,7 @@
-import type { JsonObject } from "@pluv/types";
 import { fromUint8Array, toUint8Array } from "js-base64";
 import type { AbstractType, Map as YMap, Transaction } from "yjs";
 import { applyUpdate, Doc as YDoc, encodeStateAsUpdate } from "yjs";
+import type { InferYjsDocJson } from "./types";
 
 export class YjsDoc<T extends Record<string, AbstractType<any>> = {}> {
     public value: YDoc = new YDoc();
@@ -70,8 +70,8 @@ export class YjsDoc<T extends Record<string, AbstractType<any>> = {}> {
         };
     }
 
-    public toJSON(): JsonObject {
-        return this._storage.toJSON();
+    public toJSON(): InferYjsDocJson<this> {
+        return this._storage.toJSON() as InferYjsDocJson<this>;
     }
 
     public static fromUint8Array(u8a: Uint8Array): string {

--- a/packages/crdt-yjs/src/index.ts
+++ b/packages/crdt-yjs/src/index.ts
@@ -5,6 +5,11 @@ export { map } from "./map";
 export type { unstable__YObject } from "./object";
 export { unstable__object } from "./object";
 export { text } from "./text";
+export type { XmlElementParams } from "./xmlElement";
+export { xmlElement } from "./xmlElement";
+export type { XmlFragmentParams } from "./xmlFragment";
+export { xmlFragment } from "./xmlFragment";
+export { xmlText } from "./xmlText";
 export type {
     InferYjsDocJson,
     InferYjsDocSharedType,

--- a/packages/crdt-yjs/src/types.ts
+++ b/packages/crdt-yjs/src/types.ts
@@ -3,6 +3,9 @@ import type {
     Array as YArray,
     Map as YMap,
     Text as YText,
+    XmlElement as YXmlElement,
+    XmlFragment as YXmlFragment,
+    XmlText as YXmlText,
 } from "yjs";
 import type { YjsDoc } from "./doc";
 import type { unstable__YObject } from "./object";
@@ -34,7 +37,7 @@ export type InferYjsSharedTypeJson<TShared extends unknown> =
             ? { [P in keyof IObject]: InferYjsSharedTypeJson<IObject[P]> }
             : TShared extends YMap<infer IItem>
             ? Record<string, InferYjsSharedTypeJson<IItem>>
-            : TShared extends YText
+            : TShared extends YText | YXmlElement | YXmlFragment | YXmlText
             ? string
             : never
         : TShared;

--- a/packages/crdt-yjs/src/xmlElement.ts
+++ b/packages/crdt-yjs/src/xmlElement.ts
@@ -1,0 +1,19 @@
+import type { XmlText as YXmlText } from "yjs";
+import { XmlElement as YXmlElement } from "yjs";
+
+export interface XmlElementParams {
+    children?: readonly (YXmlElement | YXmlText)[];
+}
+
+export const xmlElement = (
+    name: string,
+    params: XmlElementParams = {}
+): YXmlElement => {
+    const { children = [] } = params;
+
+    const element = new YXmlElement(name);
+
+    element.push(children.slice());
+
+    return element;
+};

--- a/packages/crdt-yjs/src/xmlFragment.ts
+++ b/packages/crdt-yjs/src/xmlFragment.ts
@@ -1,0 +1,16 @@
+import type { XmlElement as YXmlElement, XmlText as YXmlText } from "yjs";
+import { XmlFragment as YXmlFragment } from "yjs";
+
+export interface XmlFragmentParams {
+    children?: readonly (YXmlElement | YXmlText)[];
+}
+
+export const xmlFragment = (params: XmlFragmentParams = {}): YXmlFragment => {
+    const { children = [] } = params;
+
+    const fragment = new YXmlFragment();
+
+    fragment.push(children.slice());
+
+    return fragment;
+};

--- a/packages/crdt-yjs/src/xmlText.ts
+++ b/packages/crdt-yjs/src/xmlText.ts
@@ -1,0 +1,5 @@
+import { XmlText as YXmlText } from "yjs";
+
+export const xmlText = (value: string = ""): YXmlText => {
+    return new YXmlText(value);
+};

--- a/packages/io/README.md
+++ b/packages/io/README.md
@@ -124,9 +124,9 @@ And more. With **E2E type-safety**, **great intellisense** and the **[yjs](https
     - ✅ [Map](https://docs.yjs.dev/api/shared-types/y.map)
     - ✅ [Array](https://docs.yjs.dev/api/shared-types/y.array)
     - ✅ [Text](https://docs.yjs.dev/api/shared-types/y.text)
-    - ⬜ [XmlFragment](https://docs.yjs.dev/api/shared-types/y.xmlfragment)
-    - ⬜ [XmlElement](https://docs.yjs.dev/api/shared-types/y.xmlelement)
-    - ⬜ [XmlText](https://docs.yjs.dev/api/shared-types/y.xmltext)
+    - ✅ [XmlFragment](https://docs.yjs.dev/api/shared-types/y.xmlfragment)
+    - ✅ [XmlElement](https://docs.yjs.dev/api/shared-types/y.xmlelement)
+    - ✅ [XmlText](https://docs.yjs.dev/api/shared-types/y.xmltext)
 - ⬜ Studio (admin & developer panel)
 
 ### Runtimes


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] I have added or updated the tests related to the changes made.

---

## Changelog

Added support for remaining yjs shared types: `y.xmlFragment`, `y.xmlElement` and `y.xmlText`.