### PR TITLE
ci: replaced auto-assign action

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,19 +1,14 @@
 name: Auto Assign
 on:
   issues:
-    types: [opened]
+    types: [opened, reopened]
   pull_request:
-    types: [opened]
+    types: [opened, reopened]
+permissions:
+  issues: write
+  pull-requests: write
 jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: wow-actions/auto-assign@v3
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          addReviewers: true
-          addAssignees: author
-          reviewers: leedavidcs
-          numberOfReviewers: 0
-          skipKeywords: draft, wip
-          excludeLabels: renovate
+      - uses: toshimaru/auto-author-assign@v1.6.2


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] I have added or updated the tests related to the changes made.

---

## Changelog

* Replaced auto assign GitHub action to self-assign PRs and issues.