### PR TITLE
feat: return room from PluvClient.createRoom

### DIFF
--- a/.changeset/eleven-apricots-trade.md
+++ b/.changeset/eleven-apricots-trade.md
@@ -1,0 +1,5 @@
+---
+"@pluv/client": minor
+---
+
+updated createRoom options to be optional

--- a/.changeset/eleven-apricots-trade.md
+++ b/.changeset/eleven-apricots-trade.md
@@ -2,4 +2,4 @@
 "@pluv/client": minor
 ---
 
-updated createRoom options to be optional
+changed `PluvClient.createRoom` to have optional options.

--- a/.changeset/five-maps-dance.md
+++ b/.changeset/five-maps-dance.md
@@ -2,4 +2,4 @@
 "@pluv/client": minor
 ---
 
-return room after PluvRoom.enter
+changed `PluvClient.enter` to return the `PluvRoom` that was entered.

--- a/.changeset/five-maps-dance.md
+++ b/.changeset/five-maps-dance.md
@@ -1,0 +1,5 @@
+---
+"@pluv/client": minor
+---
+
+return room after PluvRoom.enter

--- a/apps/web/src/components/DocsBreadcrumbs/DocsBreadcrumbs.tsx
+++ b/apps/web/src/components/DocsBreadcrumbs/DocsBreadcrumbs.tsx
@@ -19,6 +19,7 @@ export const DocsBreadcrumbs = memo<DocsBreadcrumbsProps>((props) => {
     const router = useRouter();
 
     const slugs = router.asPath
+        .replace(/#.+$/g, "")
         .replace(/^(\/)?docs(\/)?/, "")
         .split("/")
         .filter((slug) => !!slug);

--- a/apps/web/src/components/DocsTreeViewNavigation/DocsTreeViewNavigationRoutes.tsx
+++ b/apps/web/src/components/DocsTreeViewNavigation/DocsTreeViewNavigationRoutes.tsx
@@ -26,6 +26,7 @@ export const DocsTreeViewNavigationRoutes: FC<
 
     const slugs = useMemo(() => {
         return router.asPath
+            .replace(/#.+$/g, "")
             .replace(new RegExp(`^${baseRoute}`), "")
             .replace(/^\//, "")
             .split("/");

--- a/packages/client/src/PluvClient.ts
+++ b/packages/client/src/PluvClient.ts
@@ -56,7 +56,7 @@ export class PluvClient<TIO extends IOLike = IOLike> {
 
     public enter = async (
         room: string | PluvRoom<TIO, JsonObject, any>
-    ): Promise<void> => {
+    ): Promise<PluvRoom<TIO, JsonObject, any>> => {
         const toEnter = typeof room === "string" ? this.getRoom(room) : room;
 
         if (!toEnter) {
@@ -68,6 +68,8 @@ export class PluvClient<TIO extends IOLike = IOLike> {
         await toEnter.connect();
 
         this._logDebug(`Entered room: ${room}`);
+
+        return toEnter;
     };
 
     public getRoom = <

--- a/packages/client/src/PluvClient.ts
+++ b/packages/client/src/PluvClient.ts
@@ -32,7 +32,7 @@ export class PluvClient<TIO extends IOLike = IOLike> {
         TStorage extends Record<string, AbstractType<any>> = {}
     >(
         room: string,
-        options: PluvRoomOptions<TIO, TPresence, TStorage>
+        options: PluvRoomOptions<TIO, TPresence, TStorage> = {}
     ): PluvRoom<TIO, TPresence, TStorage> => {
         const oldRoom = this.getRoom<TPresence, TStorage>(room);
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] I have added or updated the tests related to the changes made.

---

## Changelog

* Changed `PluvClient.enter` to return the `PluvRoom` that was entered.
* Changed `PluvClient.createRoom` to have optional options.