### PR TITLE
fix: changed MockedRoom events to accept partial event mocks

### DIFF
--- a/.changeset/ninety-dogs-live.md
+++ b/.changeset/ninety-dogs-live.md
@@ -1,0 +1,6 @@
+---
+"@pluv/client": patch
+"@pluv/react": patch
+---
+
+updated MockedRoomProvider events to allow partial events

--- a/packages/client/src/MockedRoom.ts
+++ b/packages/client/src/MockedRoom.ts
@@ -29,11 +29,11 @@ import { ConnectionState } from "./types";
 import type { UsersManagerConfig } from "./UsersManager";
 import { UsersManager } from "./UsersManager";
 
-export type MockedRoomEvents<TIO extends IOLike> = {
+export type MockedRoomEvents<TIO extends IOLike> = Partial<{
     [P in keyof InferIOInput<TIO>]: (
         data: Id<InferIOInput<TIO>[P]>
     ) => Partial<InferIOOutput<TIO>>;
-};
+}>;
 
 export type MockedRoomConfig<
     TIO extends IOLike,

--- a/packages/react/src/createBundle.tsx
+++ b/packages/react/src/createBundle.tsx
@@ -3,11 +3,11 @@ import type { IOLike, JsonObject } from "@pluv/types";
 import { createContext, FC, ReactNode } from "react";
 import { memo, useContext } from "react";
 import type { AbstractType } from "yjs";
-import {
+import type {
     CreateRoomBundle,
-    createRoomBundle as _createRoomBundle,
     CreateRoomBundleOptions,
 } from "./createRoomBundle";
+import { createRoomBundle as _createRoomBundle } from "./createRoomBundle";
 
 export interface PluvProviderProps {
     children?: ReactNode;


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] I have added or updated the tests related to the changes made.

---

## Changelog

Fixed MockedRoom events always requiring all events to be mocked.