### PR TITLE
feat: prevent rerender on deep equal

### DIFF
--- a/.changeset/silent-wasps-sing.md
+++ b/.changeset/silent-wasps-sing.md
@@ -1,0 +1,5 @@
+---
+"@pluv/react": patch
+---
+
+updated react hooks to not re-render if state is deeply equal by default

--- a/packages/react/src/createRoomBundle.tsx
+++ b/packages/react/src/createRoomBundle.tsx
@@ -282,7 +282,7 @@ export const createRoomBundle = <
             getSnapshot,
             getSnapshot,
             _selector,
-            options?.isEqual
+            options?.isEqual ?? fastDeepEqual
         );
     };
 
@@ -328,7 +328,7 @@ export const createRoomBundle = <
             getSnapshot,
             getSnapshot,
             _selector,
-            options?.isEqual
+            options?.isEqual ?? fastDeepEqual
         );
 
         const updateMyPresence: Dispatch<UpdateMyPresenceAction<TPresence>> =
@@ -378,7 +378,7 @@ export const createRoomBundle = <
             getSnapshot,
             getSnapshot,
             _selector,
-            options?.isEqual
+            options?.isEqual ?? fastDeepEqual
         );
     };
 
@@ -413,7 +413,7 @@ export const createRoomBundle = <
             getSnapshot,
             getSnapshot,
             _selector,
-            options?.isEqual
+            options?.isEqual ?? fastDeepEqual
         );
     };
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] I have added or updated the tests related to the changes made.

---

## Changelog

Updated @pluv/react to prevent rerendering if state values are deeply equal by default.