### PR TITLE
feat: use existing presence of reconnected user

### DIFF
--- a/.changeset/slow-pears-mix.md
+++ b/.changeset/slow-pears-mix.md
@@ -1,0 +1,7 @@
+---
+"@pluv/client": minor
+"@pluv/types": minor
+"@pluv/io": minor
+---
+
+updated offline presence to be set when reconnecting to a room

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -622,13 +622,13 @@ export class PluvRoom<
             user as Id<InferIOAuthorizeUser<InferIOAuthorize<TIO>>>
         );
 
-        const myPresence = this._usersManager.myPresence;
+        const presence = this._usersManager.myPresence;
         const myself = this._usersManager.myself ?? null;
 
-        this._stateNotifier.subjects["my-presence"].next(myPresence);
+        this._stateNotifier.subjects["my-presence"].next(presence);
         this._stateNotifier.subjects["myself"].next(myself);
 
-        this._sendMessage({ type: "$GET_OTHERS", data: {} });
+        this._sendMessage({ type: "$INITIALIZE_SESSION", data: { presence } });
     }
 
     private _handleStorageReceivedMessage(message: IOEventMessage<TIO>): void {
@@ -708,7 +708,17 @@ export class PluvRoom<
             InferIOAuthorize<TIO>
         >["$USER_JOINED"];
 
-        this._usersManager.setUser(connectionId, data.user);
+        const myself = this._usersManager.myself;
+
+        if (myself.connectionId === connectionId) {
+            this._sendMessage({ type: "$GET_OTHERS", data: {} });
+        }
+
+        this._usersManager.setUser(
+            connectionId,
+            data.user,
+            data.presence as TPresence
+        );
 
         const other = this._usersManager.getOther(connectionId);
         const others = this._usersManager.getOthers();

--- a/packages/client/src/UsersManager.ts
+++ b/packages/client/src/UsersManager.ts
@@ -128,7 +128,8 @@ export class UsersManager<
 
     public setUser(
         connectionId: string,
-        user: Id<InferIOAuthorizeUser<InferIOAuthorize<TIO>>>
+        user: Id<InferIOAuthorizeUser<InferIOAuthorize<TIO>>>,
+        presence?: TPresence
     ): void {
         if (this._myself?.connectionId === connectionId) return;
 
@@ -138,7 +139,7 @@ export class UsersManager<
 
         this._others.set(connectionId, {
             connectionId,
-            presence: this._initialPresence,
+            presence: presence ?? this._initialPresence,
             user,
         });
     }

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -220,7 +220,6 @@ export class IORoom<
 
         this._emitRegistered(session);
         this._emitStorageReceived(session);
-        this._emitUserJoined(session);
 
         this._logDebug(
             `${colors.blue(
@@ -298,23 +297,6 @@ export class IORoom<
                     session
                 );
             });
-    }
-
-    private _emitUserJoined(session: WebSocketSession): void {
-        const user = session.user as any;
-
-        if (!user) return;
-
-        this._broadcast({
-            message: {
-                type: "$USER_JOINED",
-                data: {
-                    connectionId: session.id,
-                    user,
-                },
-            },
-            senderId: session.id,
-        });
     }
 
     private async _getAuthorizedUser(

--- a/packages/io/src/PluvIO.ts
+++ b/packages/io/src/PluvIO.ts
@@ -85,18 +85,6 @@ export class PluvIO<
     readonly _authorize: TAuthorize | null = null;
     readonly _debug: boolean;
     readonly _events: InferEventConfig<TContext, TInput, TOutput> = {
-        $PING: {
-            resolver: (data, { session }) => {
-                if (!session) return {};
-
-                const currentTime = new Date().getTime();
-
-                session.timers.ping = currentTime;
-
-                return { $PONG: {} };
-            },
-            options: { type: "self" },
-        },
         $GET_OTHERS: {
             resolver: (data, { room, session, sessions }) => {
                 const others = Array.from(sessions.entries())
@@ -123,6 +111,33 @@ export class PluvIO<
                 return { $OTHERS_RECEIVED: { others } };
             },
             options: { type: "sync" },
+        },
+        $INITIALIZE_SESSION: {
+            resolver: ({ presence }, { session }) => {
+                if (!session) return {};
+
+                session.presence = presence;
+
+                return {
+                    $USER_JOINED: {
+                        connectionId: session.id,
+                        user: session.user,
+                        presence,
+                    },
+                };
+            },
+        },
+        $PING: {
+            resolver: (data, { session }) => {
+                if (!session) return {};
+
+                const currentTime = new Date().getTime();
+
+                session.timers.ping = currentTime;
+
+                return { $PONG: {} };
+            },
+            options: { type: "self" },
         },
         $UPDATE_PRESENCE: {
             resolver: ({ presence }, { session }) => {

--- a/packages/types/src/pluv.ts
+++ b/packages/types/src/pluv.ts
@@ -6,6 +6,9 @@ export type BaseUser = {
 
 export interface BaseClientEventRecord {
     $GET_OTHERS: {};
+    $INITIALIZE_SESSION: {
+        presence: JsonObject;
+    };
     $PING: {};
     $UPDATE_PRESENCE: {
         presence: JsonObject;
@@ -40,6 +43,7 @@ export interface BaseIOAuthorizeEventRecord<
     $USER_JOINED: {
         connectionId: string;
         user: NonNullable<InferIOAuthorizeUser<TAuthorize>>;
+        presence: JsonObject;
     };
 }
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] I have added or updated the tests related to the changes made.

---

## Changelog

Updated `$USER_JOINED` event to use the user's current presence if they had one previously (for example if they lost network connection, and updated their presence).