### PR TITLE
feat: new io initial storage

### DIFF
--- a/.changeset/quiet-flies-burn.md
+++ b/.changeset/quiet-flies-burn.md
@@ -1,0 +1,31 @@
+---
+"@pluv/io": minor
+---
+
+Updated createIO config option `initialStorage` to be renamed to `getInitialStorage` and updated the params to use an object that includes platform parameters.
+
+Previously:
+```ts
+createIO({
+    initialStorage(room: string): Promise<string> => {
+        // ...
+    },
+});
+```
+
+Now:
+```ts
+createIO({
+    platform: platformCloudflare<Env>(),
+    getInitialStorage({
+        // If you're using Cloudflare, this is the Cloudflare env parameter
+        env,
+        // The name of the room
+        room,
+    }): Promise<string> => {
+        // ...
+    },
+});
+```
+
+

--- a/packages/io/src/createIO.ts
+++ b/packages/io/src/createIO.ts
@@ -8,7 +8,7 @@ import type {
     MaybePromise,
 } from "@pluv/types";
 import type { AbstractPlatform } from "./AbstractPlatform";
-import type { PluvIOListeners } from "./PluvIO";
+import type { GetInitialStorageFn, PluvIOListeners } from "./PluvIO";
 import { PluvIO } from "./PluvIO";
 
 export type CreateIOParams<
@@ -20,7 +20,7 @@ export type CreateIOParams<
     authorize?: IOAuthorize<TAuthorizeUser, TAuthorizeRequired>;
     context?: TContext;
     debug?: boolean;
-    initialStorage?: (room: string) => MaybePromise<Maybe<string>>;
+    getInitialStorage?: GetInitialStorageFn<TPlatform>;
     platform: TPlatform;
 };
 
@@ -47,7 +47,7 @@ export const createIO = <
         authorize,
         context,
         debug,
-        initialStorage,
+        getInitialStorage,
         onRoomDeleted,
         onStorageUpdated,
         platform,
@@ -63,7 +63,7 @@ export const createIO = <
         authorize,
         context,
         debug,
-        initialStorage,
+        getInitialStorage,
         onRoomDeleted,
         onStorageUpdated,
         platform,

--- a/packages/io/src/index.ts
+++ b/packages/io/src/index.ts
@@ -26,7 +26,12 @@ export type {
     AbstractWebSocketHandleErrorParams,
 } from "./AbstractWebSocket";
 export type { IORoom } from "./IORoom";
-export type { GetRoomOptions, InferIORoom, PluvIO } from "./PluvIO";
+export type {
+    GetRoomOptions,
+    InferIORoom,
+    PluvIO,
+    PluvIOConfig,
+} from "./PluvIO";
 export type {
     AuthorizeModule,
     AuthorizeParams,

--- a/tests/e2e/src/server/node/pluv-io.ts
+++ b/tests/e2e/src/server/node/pluv-io.ts
@@ -25,7 +25,7 @@ export const io = createIO({
             update: { storage },
         });
     },
-    initialStorage: async (name) => {
+    getInitialStorage: async ({ room: name }) => {
         if (name !== "e2e-node-storage-saved") return null;
 
         const room = await prisma.room.findUnique({ where: { name } });


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] I have added or updated the tests related to the changes made.

---

## Changelog

Updated `initialStorage` to be renamed to `getInitialStorage`. Changed parameters to use a parameterized object that includes the platform context and the room name.