### PR TITLE
feat: expose xml yjs types

### DIFF
--- a/.changeset/tame-ants-clap.md
+++ b/.changeset/tame-ants-clap.md
@@ -1,0 +1,18 @@
+---
+"@pluv/crdt-yjs": patch
+"@pluv/client": patch
+"@pluv/react": patch
+---
+
+* Renamed type `unstable_YObjectValue` to `YObjectValue`;
+* Renamed type `unstable_YObject` to `YObject`.
+* Re-exported `xmlElement`, `xmlFragment` and `xmlText` from `@pluv/client`.
+  ```ts
+  import { y } from "@pluv/client"
+  // or
+  import { y } from "@pluv/react";
+
+  y.xmlElement("MyElement", {});
+  y.xmlFragment({});
+  y.xmlText("hello world");
+  ```

--- a/packages/client/src/y.ts
+++ b/packages/client/src/y.ts
@@ -1,1 +1,9 @@
-export { array, map, text, object } from "@pluv/crdt-yjs";
+export {
+    array,
+    map,
+    object,
+    text,
+    xmlElement,
+    xmlFragment,
+    xmlText,
+} from "@pluv/crdt-yjs";

--- a/packages/crdt-yjs/src/index.ts
+++ b/packages/crdt-yjs/src/index.ts
@@ -1,15 +1,10 @@
 export type { AbstractType, Array, Map, Text } from "yjs";
 export { array } from "./array";
-export { doc, YjsDoc } from "./doc";
+export { YjsDoc, doc } from "./doc";
 export { map } from "./map";
-export type { unstable__YObject } from "./object";
 export { object } from "./object";
+export type { YObject, YObjectValue } from "./object";
 export { text } from "./text";
-export type { XmlElementParams } from "./xmlElement";
-export { xmlElement } from "./xmlElement";
-export type { XmlFragmentParams } from "./xmlFragment";
-export { xmlFragment } from "./xmlFragment";
-export { xmlText } from "./xmlText";
 export type {
     InferYjsDocJson,
     InferYjsDocSharedType,
@@ -17,3 +12,8 @@ export type {
     InferYjsDocSharedTypes,
     InferYjsSharedTypeJson,
 } from "./types";
+export { xmlElement } from "./xmlElement";
+export type { XmlElementParams } from "./xmlElement";
+export { xmlFragment } from "./xmlFragment";
+export type { XmlFragmentParams } from "./xmlFragment";
+export { xmlText } from "./xmlText";

--- a/packages/crdt-yjs/src/object.ts
+++ b/packages/crdt-yjs/src/object.ts
@@ -2,17 +2,15 @@ import type { JsonPrimitive } from "@pluv/types";
 import type { AbstractType } from "yjs";
 import { Map as YMap } from "yjs";
 
-export type unstable__YObjectValue = Record<
+export type YObjectValue = Record<
     string,
     NonNullable<JsonPrimitive> | AbstractType<any>
 >;
 
-export type unstable__YObject<T extends unstable__YObjectValue> = YMap<
-    T[keyof T]
-> & { __$type: T };
+export type YObject<T extends YObjectValue> = YMap<T[keyof T]> & {
+    __$type: T;
+};
 
-export const object = <T extends unstable__YObjectValue = {}>(
-    value: T,
-): unstable__YObject<T> => {
-    return new YMap(Object.entries(value)) as unstable__YObject<T>;
+export const object = <T extends YObjectValue = {}>(value: T): YObject<T> => {
+    return new YMap(Object.entries(value)) as YObject<T>;
 };

--- a/packages/crdt-yjs/src/types.ts
+++ b/packages/crdt-yjs/src/types.ts
@@ -8,7 +8,7 @@ import type {
     XmlText as YXmlText,
 } from "yjs";
 import type { YjsDoc } from "./doc";
-import type { unstable__YObject } from "./object";
+import type { YObject } from "./object";
 
 export type InferYjsDocJson<TDoc extends YjsDoc<any>> = TDoc extends YjsDoc<
     infer ITypes
@@ -35,7 +35,7 @@ export type InferYjsSharedTypeJson<TShared extends unknown> =
     TShared extends AbstractType<any>
         ? TShared extends YArray<infer IItem>
             ? readonly InferYjsSharedTypeJson<IItem>[]
-            : TShared extends unstable__YObject<infer IObject>
+            : TShared extends YObject<infer IObject>
             ? { [P in keyof IObject]: InferYjsSharedTypeJson<IObject[P]> }
             : TShared extends YMap<infer IItem>
             ? Record<string, InferYjsSharedTypeJson<IItem>>


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

* Renamed type `unstable_YObjectValue` to `YObjectValue`;
* Renamed type `unstable_YObject` to `YObject`.
* Re-exported `xmlElement`, `xmlFragment` and `xmlText` from `@pluv/client`.
  ```ts
  import { y } from "@pluv/client"
  // or
  import { y } from "@pluv/react";

  y.xmlElement("MyElement", {});
  y.xmlFragment({});
  y.xmlText("hello world");
  ```
