### PR TITLE
feat(io): expose io context and get initial storage

### DIFF
--- a/.changeset/lemon-eels-clap.md
+++ b/.changeset/lemon-eels-clap.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": patch
+---
+
+Exposed context and getInitialProps from @pluv/io.

--- a/packages/io/src/PluvIO.ts
+++ b/packages/io/src/PluvIO.ts
@@ -107,8 +107,6 @@ export class PluvIO<
 > implements
         IOLike<TAuthorize, TInput, TOutputBroadcast, TOutputSelf, TOutputSync>
 {
-    private _context: TContext = {} as TContext;
-    private _getInitialStorage: GetInitialStorageFn<TPlatform> | null = null;
     private _rooms = new Map<
         string,
         IORoom<
@@ -123,6 +121,7 @@ export class PluvIO<
     >();
 
     readonly _authorize: TAuthorize | null = null;
+    readonly _context: TContext = {} as TContext;
     readonly _debug: boolean;
     readonly _events: InferEventConfig<
         TPlatform,
@@ -274,6 +273,7 @@ export class PluvIO<
         TOutputSelf,
         TOutputSync
     >;
+    readonly _getInitialStorage: GetInitialStorageFn<TPlatform> | null = null;
     readonly _listeners: PluvIOListeners<TPlatform>;
     readonly _platform: TPlatform;
 
@@ -492,8 +492,14 @@ export class PluvIO<
     > {
         const authorize = (first._authorize ??
             undefined) as InferIOAuthorize<TIO1>;
+        const context = first._context as InferIOContext<TIO1>;
         const debug = first._debug;
         const platform = first._platform as InferIOPlatform<TIO1>;
+
+        const getInitialStorage =
+            first._getInitialStorage as GetInitialStorageFn<
+                InferIOPlatform<TIO1>
+            >;
 
         const events1 = first._events;
         const events2 = second._events;
@@ -504,8 +510,10 @@ export class PluvIO<
 
         return new PluvIO({
             authorize,
+            context,
             debug,
             events,
+            getInitialStorage,
             onRoomDeleted,
             onStorageUpdated,
             platform,


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Expose io context and getInitialStorage.