### PR TITLE
feat(client): update storage to never be null

### DIFF
--- a/apps/web/src/inputs/docs/@pluv_client/API Reference.mdx
+++ b/apps/web/src/inputs/docs/@pluv_client/API Reference.mdx
@@ -524,7 +524,7 @@ room.transact((tx) => {
     tx.messages.push(["hello world!"]);
 });
 
-// This will also be undoable because `"user-123"` is a tracked origin.
+// This will also be undoable if `"user-123"` is a tracked origin.
 room.transact(() => {
     room.get("messages").push(["hello world!"]);
 }, "user-123");

--- a/apps/web/src/inputs/docs/@pluv_react/API Reference.mdx
+++ b/apps/web/src/inputs/docs/@pluv_react/API Reference.mdx
@@ -378,7 +378,7 @@ transact((tx) => {
     tx.messages.push(["hello world!"]);
 });
 
-// This will also be undoable because `"user-123"` is a tracked origin.
+// This will also be undoable if `"user-123"` is a tracked origin.
 transact(() => {
     sharedType?.push(["hello world!"]);
 }, "user-123");

--- a/packages/client/src/AbstractRoom.ts
+++ b/packages/client/src/AbstractRoom.ts
@@ -54,7 +54,7 @@ export abstract class AbstractRoom<
 
     public abstract getStorage<TKey extends keyof TStorage>(
         key: TKey,
-    ): TStorage[TKey] | null;
+    ): TStorage[TKey];
 
     public abstract other(
         connectionId: string,

--- a/packages/client/src/MockedRoom.ts
+++ b/packages/client/src/MockedRoom.ts
@@ -50,7 +50,7 @@ export class MockedRoom<
     TPresence extends JsonObject = {},
     TStorage extends Record<string, AbstractType<any>> = {},
 > extends AbstractRoom<TIO, TPresence, TStorage> {
-    private _crdtManager: CrdtManager<TStorage> | null = null;
+    private _crdtManager: CrdtManager<TStorage>;
     private _crdtNotifier = new CrdtNotifier<TStorage>();
     private _eventNotifier = new EventNotifier<TIO>();
     private _events?: MockedRoomEvents<TIO>;
@@ -118,11 +118,11 @@ export class MockedRoom<
     }
 
     public canRedo = (): boolean => {
-        return !!this._crdtManager?.doc.canRedo();
+        return !!this._crdtManager.doc.canRedo();
     };
 
     public canUndo = (): boolean => {
-        return !!this._crdtManager?.doc.canUndo();
+        return !!this._crdtManager.doc.canUndo();
     };
 
     public event = <TEvent extends keyof InferIOOutput<TIO>>(
@@ -159,8 +159,14 @@ export class MockedRoom<
 
     public getStorage = <TKey extends keyof TStorage>(
         key: TKey,
-    ): TStorage[TKey] | null => {
-        return this._crdtManager?.get(key) ?? null;
+    ): TStorage[TKey] => {
+        const sharedType = this._crdtManager.get(key);
+
+        if (typeof sharedType === "undefined") {
+            throw new Error(`Could not find storege: ${key.toString()}`);
+        }
+
+        return sharedType;
     };
 
     public other = (
@@ -171,7 +177,7 @@ export class MockedRoom<
     };
 
     public redo = (): void => {
-        this._crdtManager?.doc.redo();
+        this._crdtManager.doc.redo();
     };
 
     public storage = <TKey extends keyof TStorage>(
@@ -221,7 +227,7 @@ export class MockedRoom<
     };
 
     public undo = (): void => {
-        this._crdtManager?.doc.undo();
+        this._crdtManager.doc.undo();
     };
 
     public updateMyPresence = (presence: Partial<TPresence>): void => {

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -345,7 +345,7 @@ export class PluvRoom<
 
         await this._storageStore.destroy();
 
-        this._crdtManager?.destroy();
+        this._crdtManager.destroy();
 
         this._stateNotifier.subjects["my-presence"].next(null);
     }
@@ -384,8 +384,14 @@ export class PluvRoom<
 
     public getStorage = <TKey extends keyof TStorage>(
         key: TKey,
-    ): TStorage[TKey] | null => {
-        return this._crdtManager?.get(key) ?? null;
+    ): TStorage[TKey] => {
+        const sharedType = this._crdtManager.get(key);
+
+        if (typeof sharedType === "undefined") {
+            throw new Error(`Could not find storege: ${key.toString()}`);
+        }
+
+        return sharedType;
     };
 
     public other = (
@@ -826,7 +832,7 @@ export class PluvRoom<
 
         const update =
             this._state.connection.count > 1
-                ? this._crdtManager?.doc.encodeStateAsUpdate() ?? null
+                ? this._crdtManager.doc.encodeStateAsUpdate() ?? null
                 : null;
 
         this._sendMessage({

--- a/packages/react/src/createRoomBundle.tsx
+++ b/packages/react/src/createRoomBundle.tsx
@@ -136,8 +136,8 @@ export interface CreateRoomBundle<
     >(
         key: TKey,
         selector?: (data: InferYjsSharedTypeJson<TStorage[TKey]>) => TData,
-        options?: SubscriptionHookOptions<TData | null>,
-    ) => [data: TData | null, sharedType: TStorage[TKey] | null];
+        options?: SubscriptionHookOptions<TData>,
+    ) => [data: TData, sharedType: TStorage[TKey]];
     usePluvTransact: () => (
         fn: (storage: TStorage) => void,
         origin?: string,
@@ -517,8 +517,8 @@ export const createRoomBundle = <
         selector = identity as (
             data: InferYjsSharedTypeJson<TStorage[TKey]>,
         ) => TData,
-        options?: SubscriptionHookOptions<TData | null>,
-    ): [data: TData | null, sharedType: TStorage[TKey] | null] => {
+        options?: SubscriptionHookOptions<TData>,
+    ): [data: TData, sharedType: TStorage[TKey]] => {
         const room = usePluvRoom();
 
         const subscribe = useCallback(
@@ -528,13 +528,13 @@ export const createRoomBundle = <
 
         const getSnapshot = useCallback((): InferYjsSharedTypeJson<
             TStorage[TKey]
-        > | null => {
-            return room.getStorage(key)?.toJSON() ?? null;
+        > => {
+            return room.getStorage(key).toJSON();
         }, [key, room]);
 
         const _selector = useCallback(
-            (snapshot: InferYjsSharedTypeJson<TStorage[TKey]> | null) => {
-                return !snapshot ? null : selector(snapshot);
+            (snapshot: InferYjsSharedTypeJson<TStorage[TKey]>) => {
+                return selector(snapshot);
             },
             [selector],
         );


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Updated storage from `getStorage` to never return null.