### PR TITLE
feat(client): expose the root yjs doc from room

### DIFF
--- a/.changeset/soft-boxes-poke.md
+++ b/.changeset/soft-boxes-poke.md
@@ -1,0 +1,15 @@
+---
+"@pluv/client": minor
+---
+
+Added `getDoc` on `PluvRoom` to access the root Yjs doc.
+
+```ts
+import { createClient } from "@pluv/client";
+import type { Doc } from "yjs";
+
+const client = createClient(/* ... */);
+const room = client.createRoom(/* ... */);
+
+const doc: Doc = room.getDoc();
+```

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -12,7 +12,7 @@ import type {
     IOLike,
     JsonObject,
 } from "@pluv/types";
-import type { AbstractType } from "yjs";
+import type { AbstractType, Doc } from "yjs";
 import { AbstractRoom } from "./AbstractRoom";
 import { AbstractStorageStore } from "./AbstractStorageStore";
 import type { CrdtManagerOptions } from "./CrdtManager";
@@ -362,6 +362,10 @@ export class PluvRoom<
         return Object.freeze(
             JSON.parse(JSON.stringify(this._state.connection)),
         );
+    }
+
+    public getDoc(): Doc {
+        return this._crdtManager.doc.value;
     }
 
     public getMyPresence = (): TPresence => {


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Added `getDoc` to `PluvRoom` to be able to access the root Yjs document.