### PR TITLE
feat(react): rename hooks

### DIFF
--- a/.changeset/plenty-boats-jog.md
+++ b/.changeset/plenty-boats-jog.md
@@ -1,0 +1,5 @@
+---
+"@pluv/react": minor
+---
+
+Renamed all hooks from `@pluv/react` to be simply prefixed with `use` instead of `usePluv` (e.g. `usePluvStorage` is now just `useStorage`).

--- a/.changeset/plenty-boats-jog.md
+++ b/.changeset/plenty-boats-jog.md
@@ -3,3 +3,14 @@
 ---
 
 Renamed all hooks from `@pluv/react` to be simply prefixed with `use` instead of `usePluv` (e.g. `usePluvStorage` is now just `useStorage`).
+
+Hooks can be aliased to retain the same names if preferred:
+
+```ts
+export const {
+    // ...
+    useStorage: usePluvStorage,
+    useTransact: usePluvTransact,
+    // ...
+} = createRoomBundle(/* */);
+```

--- a/.changeset/proud-berries-itch.md
+++ b/.changeset/proud-berries-itch.md
@@ -30,7 +30,7 @@
     // After:
     import { yjs } from "@pluv/crdt-yjs";
     ```
-* `@pluv/crdt-yjs` functions no-longer return Yjs shared-types directly, but instead return an `AbstractCrdtType` from `@pluv/crdt` (new package). This also affects methods that return storage shared types in both `@pluv/client` and `@pluv/react` from functions like `PluvRoom.getStorage` and `PluvRoom.usePluvStorage`.
+* `@pluv/crdt-yjs` functions no-longer return Yjs shared-types directly, but instead return an `AbstractCrdtType` from `@pluv/crdt` (new package). This also affects methods that return storage shared types in both `@pluv/client` and `@pluv/react` from functions like `PluvRoom.getStorage` and `PluvRoom.useStorage`.
     ```ts
     // Before:
     import { y } from "@pluv/crdt-yjs";
@@ -144,5 +144,5 @@
     ```ts
     const sharedType = room.getStorage("messages"); // This may be null
 
-    const [data, sharedType] = usePluvStorage("messages"); // data and sharedType may both be null
+    const [data, sharedType] = useStorage("messages"); // data and sharedType may both be null
     ```

--- a/apps/web/src/components/HomeChessDemo/HomeChessDemo.tsx
+++ b/apps/web/src/components/HomeChessDemo/HomeChessDemo.tsx
@@ -16,7 +16,7 @@ import {
     useState,
 } from "react";
 import tw, { styled } from "twin.macro";
-import { usePluvStorage } from "../../pluv-io/cloudflare";
+import { useStorage } from "../../pluv-io/cloudflare";
 
 const Root = styled.div`
     ${tw`
@@ -123,7 +123,7 @@ export interface HomeChessDemoProps {
 }
 
 export const HomeChessDemo: FC<HomeChessDemoProps> = ({ className, style }) => {
-    const [demo, sharedType] = usePluvStorage("demo");
+    const [demo, sharedType] = useStorage("demo");
     const [gameOver, setGameOver] = useState<boolean>(false);
     const [winner, setWinner] = useState<string | null>();
     const chessRef = useRef<ChessBoardRef>();

--- a/apps/web/src/components/HomeChessDemo/useOtherSquares.ts
+++ b/apps/web/src/components/HomeChessDemo/useOtherSquares.ts
@@ -1,8 +1,8 @@
-import { usePluvOthers } from "pluv-io";
+import { useOthers } from "pluv-io";
 import { useMemo } from "react";
 
 export const useOtherSquares = (): Record<string, number> => {
-    const otherSquares = usePluvOthers((others) =>
+    const otherSquares = useOthers((others) =>
         others.map((other) => other.presence.demoChessSquare),
     );
 

--- a/apps/web/src/components/HomeCodeDemo/HomeCodeDemo.tsx
+++ b/apps/web/src/components/HomeCodeDemo/HomeCodeDemo.tsx
@@ -76,24 +76,24 @@ export const HomeCodeDemo = memo<HomeCodeDemoProps>((props) => {
             {
                 code: codeBlock`
                     import {
-                      usePluvMyPresence,
-                      usePluvOthers,
-                      usePluvStorage,
+                      useMyPresence,
+                      useOthers,
+                      useStorage,
                     } from "client/pluv";
                     import type { FC } from "react";
 
                     export const Room: FC = () => {
                       // Get data and yjs shared type for mutations
-                      const [boxes, sharedType] = usePluvStorage("boxes");
+                      const [boxes, sharedType] = useStorage("boxes");
                       // { first: { x: ${codePositions.first.x}, y: ${codePositions.first.y} },
                       //   second: { x: ${codePositions.second.x}, y: ${codePositions.second.y} } }
 
                       // Observe and update your selection
-                      const [selection, setPresence] = usePluvMyPresence((me) => me.selection);
+                      const [selection, setPresence] = useMyPresence((me) => me.selection);
                       setPresence({ selection: "first" });
 
                       // Get selections of other users
-                      const selections = usePluvOthers((others) => {
+                      const selections = useOthers((others) => {
                         return others.map((other) => other.presence.selection);
                       });
 
@@ -154,7 +154,7 @@ export const HomeCodeDemo = memo<HomeCodeDemoProps>((props) => {
                       PluvProvider,
 
                       // hooks
-                      usePluvClient,
+                      useClient,
                     } = createBundle(client);
 
                     export const {
@@ -163,15 +163,15 @@ export const HomeCodeDemo = memo<HomeCodeDemoProps>((props) => {
                       PluvRoomProvider,
                     
                       // hooks
-                      usePluvBroadcast,
-                      usePluvConnection,
-                      usePluvEvent,
-                      usePluvMyPresence,
-                      usePluvMyself,
-                      usePluvOther,
-                      usePluvOthers,
-                      usePluvRoom,
-                      usePluvStorage,
+                      useBroadcast,
+                      useConnection,
+                      useEvent,
+                      useMyPresence,
+                      useMyself,
+                      useOther,
+                      useOthers,
+                      useRoom,
+                      useStorage,
                     } = createRoomBundle({
                       presence: z.object({
                         selection: z.nullable(z.string()),

--- a/apps/web/src/components/HomeTypeSafetyDemo/HomeTypeSafetyDemoClient.tsx
+++ b/apps/web/src/components/HomeTypeSafetyDemo/HomeTypeSafetyDemoClient.tsx
@@ -19,7 +19,7 @@ export const HomeTypeSafetyDemoClient = memo<HomeTypeSafetyDemoClientProps>(
             (): string => codeBlock`
                 // client/Room.tsx
 
-                import { usePluvBroadcast, usePluvEvent } from "client/pluv";
+                import { useBroadcast, useEvent } from "client/pluv";
                 import { FC, useCallback, useState } from "react";
 
                 export const Room: FC = () => {
@@ -27,11 +27,11 @@ export const HomeTypeSafetyDemoClient = memo<HomeTypeSafetyDemoClientProps>(
 
                   // Listen to new messages from the server
                   // Get types from the SEND_MESSAGE resolver output
-                  usePluvEvent("MESSAGE_RECEIVED", ({${INPUT_PARAMETER}}) => {
+                  useEvent("MESSAGE_RECEIVED", ({${INPUT_PARAMETER}}) => {
                     setMessages((prev) => [...prev${NEW_MESSAGE}]);
                   });
 
-                  const broadcast = usePluvBroadcast();
+                  const broadcast = useBroadcast();
 
                   const onSubmit = useCallback((message: string) => {
                     // Broadcast to all users

--- a/apps/web/src/inputs/docs/2--Quickstart.mdx
+++ b/apps/web/src/inputs/docs/2--Quickstart.mdx
@@ -144,7 +144,7 @@ export const {
     PluvProvider,
 
     // hooks
-    usePluvClient,
+    useClient,
 } = createBundle(client);
 
 export const {
@@ -153,15 +153,15 @@ export const {
     PluvRoomProvider,
 
     // hooks
-    usePluvBroadcast,
-    usePluvConnection,
-    usePluvEvent,
-    usePluvMyPresence,
-    usePluvMyself,
-    usePluvOther,
-    usePluvOthers,
-    usePluvRoom,
-    usePluvStorage,
+    useBroadcast,
+    useConnection,
+    useEvent,
+    useMyPresence,
+    useMyself,
+    useOther,
+    useOthers,
+    useRoom,
+    useStorage,
 } = createRoomBundle();
 ```
 
@@ -187,26 +187,26 @@ export const Room: FC = () => {
 
 ### Send and receive events
 
-Use `usePluvBroadcast` and `usePluvEvent` to send and receive type-safe events in your React component.
+Use `useBroadcast` and `useEvent` to send and receive type-safe events in your React component.
 
 ```tsx
 // frontend/ChatRoom.tsx
 
 import { FC, useCallback, useState } from "react";
 import { emojiMap } from "./emojiMap";
-import { usePluvBroadcast, usePluvEvent } from "./io";
+import { useBroadcast, useEvent } from "./io";
 
 export const ChatRoom: FC = () => {
-    const broadcast = usePluvBroadcast();
+    const broadcast = useBroadcast();
 
     const [messages. setMessages] = useState<string[]>([]);
 
-    usePluvEvent("MESSAGE_RECEIVED", ({ data }) => {
+    useEvent("MESSAGE_RECEIVED", ({ data }) => {
         //                              ^? (property) data: { message: string }
         setMessages((prev) => [...prev, data.message]);
     });
 
-    usePluvEvent("EMOJI_RECEIVED", ({ data }) => {
+    useEvent("EMOJI_RECEIVED", ({ data }) => {
         //                            ^? (property) data: { emojiCode: number }
         const emoji = emojiMap[data.emojiCode];
 

--- a/apps/web/src/inputs/docs/@pluv_react/API Reference.mdx
+++ b/apps/web/src/inputs/docs/@pluv_react/API Reference.mdx
@@ -35,20 +35,20 @@ export const {
     PluvRoomProvider,
 
     // hooks
-    usePluvBroadcast,
-    usePluvCanRedo,
-    usePluvCanUndo,
-    usePluvConnection,
-    usePluvEvent,
-    usePluvMyPresence,
-    usePluvMyself,
-    usePluvOther,
-    usePluvOthers,
-    usePluvRedo,
-    usePluvRoom,
-    usePluvStorage,
-    usePluvTransact,
-    usePluvUndo,
+    useBroadcast,
+    useCanRedo,
+    useCanUndo,
+    useConnection,
+    useEvent,
+    useMyPresence,
+    useMyself,
+    useOther,
+    useOthers,
+    useRedo,
+    useRoom,
+    useStorage,
+    useTransact,
+    useUndo,
 } = createRoomBundle({
     /**
      * @description Define the initial storage for the room
@@ -90,13 +90,13 @@ export const {
 
 ### PluvProvider
 
-React provider component to allow the `PluvClient` created by `createClient` to be accessible in child components via `usePluvClient`. This is identical to importing the created client, so this is primarily useful for dependency injection when testing.
+React provider component to allow the `PluvClient` created by `createClient` to be accessible in child components via `useClient`. This is identical to importing the created client, so this is primarily useful for dependency injection when testing.
 
 ```tsx
 <PluvProvider>{children}</PluvProvider>
 ```
 
-### usePluvClient
+### useClient
 
 Returns `PluvClient`
 
@@ -182,72 +182,72 @@ import { MockedRoomProvider } from "./io";
 </PluvRoomProvider>
 ```
 
-### usePluvBroadcast
+### useBroadcast
 
 Returns `(event, data) => void`
 
 Returns a broadcast function to emit an event and data to all connected clients. This is type-safe. The first parameter `event` will be the name of the event specified when creating your backend `PluvIO` instance and the second parameter `data` will be the associated response type. See [Define Events](/docs/io/define-events) for more details.
 
 ```tsx
-const broadcast = usePluvBroadcast();
+const broadcast = useBroadcast();
 
 broadcast("EMIT_RECEIVED", { emojiCode: 123 });
 ```
 
-### usePluvCanRedo
+### useCanRedo
 
 Returns `boolean`
 
-Checks whether calling [PluvRoom.redo](/docs/react/api-reference#usePluvRedo) will mutate storage.
+Checks whether calling [PluvRoom.redo](/docs/react/api-reference#useRedo) will mutate storage.
 
 ```ts
-const canRedo: boolean = usePluvCanRedo();
+const canRedo: boolean = useCanRedo();
 ```
 
-### usePluvCanUndo
+### useCanUndo
 
 Returns `boolean`
 
-Checks whether calling [PluvRoom.undo](/docs/react/api-reference#usePluvUndo) will mutate storage.
+Checks whether calling [PluvRoom.undo](/docs/react/api-reference#useUndo) will mutate storage.
 
 ```ts
-const canUndo: boolean = usePluvCanUndo();
+const canUndo: boolean = useCanUndo();
 ```
 
-### usePluvConnection
+### useConnection
 
 Returns `WebSocketConnection`
 
 Returns the websocket connection start of the current user.
 
 ```tsx
-const connection = usePluvConnection();
+const connection = useConnection();
 //    ^? const connection: {
 //        id: string | null;
 //        state: ConnectionState;
 //    }
 ```
 
-### usePluvEvent
+### useEvent
 
 Returns `void`
 
 Defines a listener for events broadcasted by connected clients. This is type-safe. The first parameter `event` is the name of the event to listen to from your backend `PluvIO` instance. The second parameter is a callback containing the data emitted from the broadcasted event.
 
 ```tsx
-usePluvEvent("EMOJI_RECEIVED", ({ emojiCode }) => {
+useEvent("EMOJI_RECEIVED", ({ emojiCode }) => {
     console.log(emojiCode);
 });
 ```
 
-### usePluvMyPresence
+### useMyPresence
 
 Returns `[myPresence: TPresence | null, updatePresence: Function]`
 
 Returns the current user's presence, and a function to update the user's presence. Using this hook rerenders the component based on a deep-equality check on the user's presence value. This hook accepts a selector to return a modified presence to reduce rerenders.
 
 ```tsx
-const { usePluvMyPresence } = createRoomBundle({
+const { useMyPresence } = createRoomBundle({
     presence: z.object({
         selectionId: z.nullable(z.string()),
         selectionColor: z.string(),
@@ -259,7 +259,7 @@ const [
     myPresence,
     // a presence updater function
     updateMyPresence
-] = usePluvMyPresence();
+] = useMyPresence();
 
 // update individual base properties
 updateMyPresence({ selectionId: "name-input" });
@@ -272,74 +272,74 @@ updateMyPresence({
 });
 
 // if you only need a partial presence
-const [myPresence] = usePluvMyPresence(({ selectionId }) => selectionId);
+const [myPresence] = useMyPresence(({ selectionId }) => selectionId);
 
 // if you don't need presence, and just want the updater
-const [, updateMyPresence] = usePluvMyPresence(
+const [, updateMyPresence] = useMyPresence(
     // set selector to return a stable value
     () => true
 );
 ```
 
-### usePluvMyself
+### useMyself
 
 Returns `UserInfo | null`
 
 Returns the user-info object for the current user. This hook accepts a selector to return a modified user-info to reduce rerenders.
 
 ```tsx
-const myself = usePluvMyself();
+const myself = useMyself();
 
 // if you don't need the entire user-info
-const myself = usePluvMyself(({ connectionId }) => connectionId);
+const myself = useMyself(({ connectionId }) => connectionId);
 ```
 
-### usePluvOther
+### useOther
 
 Returns `UserInfo | null`
 
 Returns the user-info object for a connected user by `connectionId` string.
 
 ```tsx
-const other = usePluvOther();
+const other = useOther();
 
 // if you don't need the entire user-info
-const other = usePluvOther(({ connectionId }) => connectionId);
+const other = useOther(({ connectionId }) => connectionId);
 ```
 
-### usePluvOthers
+### useOthers
 
 Returns `readonly UserInfo[]`
 
 Returns all user-info objects for all connected users. This may trigger a lot of re-renders if presence updates frequently.
 
 > **Note**
-> Consider using this hook only for deriving others' `connectionId` values to pass into `usePluvOther`.
+> Consider using this hook only for deriving others' `connectionId` values to pass into `useOther`.
 
 ```tsx
-const others = usePluvOthers();
+const others = useOthers();
 
 // if you want to just pull out connectionId properties
-const connectionIds = usePluvOthers((others) => {
+const connectionIds = useOthers((others) => {
     return others.map(({ connectionId }) => connectionId);
 });
 ```
 
-### usePluvRedo
+### useRedo
 
 Returns `void`
 
-Re-applies the last mutation that was undone via [PluvRoom.undo](/docs/react/api-reference#usePluvUndo).
+Re-applies the last mutation that was undone via [PluvRoom.undo](/docs/react/api-reference#useUndo).
 
 For more information see: [History](/docs/react/history)
 
 ```ts
-const redo = usePluvRedo();
+const redo = useRedo();
 
 redo();
 ```
 
-### usePluvStorage
+### useStorage
 
 Returns `[TData | null, Yjs.SharedType | null]`
 
@@ -348,20 +348,20 @@ Returns a base-level property of our [yjs](https://yjs.dev) storage as a seriali
 ```tsx
 import { y } from "@pluv/react";
 
-const { usePluvStorage } = createRoomBundle({
+const { useStorage } = createRoomBundle({
     initialStorage: () => ({
         messages: y.array(["hello"]),
     }),
 });
 
-const [messages, sharedType] = usePluvStorage("messages");
+const [messages, sharedType] = useStorage("messages");
 
 sharedType.push(["world~!"]);
 
 messages.map((message, key) => <div key={key}>{message}</div>);
 ```
 
-### usePluvTransact
+### useTransact
 
 Returns `void`
 
@@ -372,8 +372,8 @@ You can specify a 2nd parameter to transact with a different transaction origin.
 For more information see: [History](/docs/react/history)
 
 ```ts
-const [messages, sharedType] = usePluvStorage("messages");
-const transact = usePluvTransact();
+const [messages, sharedType] = useStorage("messages");
+const transact = useTransact();
 
 transact((tx) => {
     sharedType.push(["hello world!"]);
@@ -388,17 +388,17 @@ transact(() => {
 }, "user-123");
 ```
 
-### usePluvUndo
+### useUndo
 
 Returns `void`
 
-Undoes the last mutation that was applied via [PluvRoom.transact](/docs/react/api-reference#usePluvTransact).
+Undoes the last mutation that was applied via [PluvRoom.transact](/docs/react/api-reference#useTransact).
 
 For more information see: [History](/docs/react/history)
 
 
 ```ts
-const undo = usePluvUndo();
+const undo = useUndo();
 
 undo();
 ```

--- a/apps/web/src/inputs/docs/@pluv_react/Create Bundle.mdx
+++ b/apps/web/src/inputs/docs/@pluv_react/Create Bundle.mdx
@@ -50,7 +50,7 @@ export const {
     PluvProvider,
 
     // hooks
-    usePluvClient,
+    useClient,
 } = createBundle(client);
 
 export const {
@@ -58,15 +58,15 @@ export const {
     PluvRoomProvider,
 
     // hooks
-    usePluvBroadcast,
-    usePluvConnection,
-    usePluvEvent,
-    usePluvMyPresence,
-    usePluvMyself,
-    usePluvOther,
-    usePluvOthers,
-    usePluvRoom,
-    usePluvStorage,
+    useBroadcast,
+    useConnection,
+    useEvent,
+    useMyPresence,
+    useMyself,
+    useOther,
+    useOthers,
+    useRoom,
+    useStorage,
 } = createRoomBundle();
 ```
 

--- a/apps/web/src/inputs/docs/@pluv_react/Custom Events.mdx
+++ b/apps/web/src/inputs/docs/@pluv_react/Custom Events.mdx
@@ -15,20 +15,20 @@ To get started, define custom events in your backend `@pluv/io` instance (see [D
 
 ## Use custom events
 
-Then, assuming you've already setup your React.js bundle and providers, listen and broadcast your custom events using `usePluvBroadcast` and `usePluvEvent` from your react bundle.
+Then, assuming you've already setup your React.js bundle and providers, listen and broadcast your custom events using `useBroadcast` and `useEvent` from your react bundle.
 
 ```ts
-import { usePluvBroadcast, usePluvEvent } from "frontend/io";
+import { useBroadcast, useEvent } from "frontend/io";
 import { useCallback } from "react";
 import { emojiMap } from "./emojiMap";
 
-usePluvEvent("EMOJI_RECEIVED", ({ data }) => {
+useEvent("EMOJI_RECEIVED", ({ data }) => {
     const emoji = emojiMap[data.emojiCode];
 
     console.log(emoji);
 });
 
-const broadcast = usePluvBroadcast();
+const broadcast = useBroadcast();
 
 const onEmoji = useCallback((emojiCode: number): void => {
     broadcast("EMIT_EMOJI", { emojiCode });

--- a/apps/web/src/inputs/docs/@pluv_react/History.mdx
+++ b/apps/web/src/inputs/docs/@pluv_react/History.mdx
@@ -13,11 +13,11 @@ This will allow users to apply undos and redos to Pluv storage mutations.
 
 ## Relevant Hooks
 
-* [usePluvCanRedo](/docs/react/api-reference#usePluvCanRedo)
-* [usePluvCanUndo](/docs/react/api-reference#usePluvCanUndo)
-* [usePluvRedo](/docs/react/api-reference#usePluvRedo)
-* [usePluvTransact](/docs/react/api-reference#usePluvTransact)
-* [usePluvUndo](/docs/react/api-reference#usePluvUndo)
+* [useCanRedo](/docs/react/api-reference#useCanRedo)
+* [useCanUndo](/docs/react/api-reference#useCanUndo)
+* [useRedo](/docs/react/api-reference#useRedo)
+* [useTransact](/docs/react/api-reference#useTransact)
+* [useUndo](/docs/react/api-reference#useUndo)
 
 ## Undoing a storage mutation
 
@@ -32,12 +32,12 @@ const client = createClient<typeof io>({ /* ... */ });
 export const { createRoomBundle } = createBundle(client);
 
 export const {
-    usePluvCanRedo,
-    usePluvCanUndo,
-    usePluvRedo,
-    usePluvStorage,
-    usePluvTransact,
-    usePluvUndo,
+    useCanRedo,
+    useCanUndo,
+    useRedo,
+    useStorage,
+    useTransact,
+    useUndo,
 } = createRoomBundle({
     initialStorage: () => ({
         messages: y.array([
@@ -53,8 +53,8 @@ export const {
 To undo a storage mutation, you will need to wrap your mutation with a transaction.
 
 ```ts
-const transact = usePluvTransact();
-const [messages, sharedType] = usePluvStorage();
+const transact = useTransact();
+const [messages, sharedType] = useStorage();
 
 // We can undo this
 transact(() => {
@@ -73,8 +73,8 @@ sharedType.push(["world!"]);
 Then from anywhere within the `PluvRoomProvider`, you can undo your last transacted operation.
 
 ```ts
-const undo = usePluvUndo();
-const redo = usePluvRedo();
+const undo = useUndo();
+const redo = useRedo();
 
 undo();
 redo();
@@ -98,7 +98,7 @@ export const { /* ... */ } = createRoomBundle({
     trackedOrigins: ["my-custom-origin"],
 });
 
-const transact = usePluvTransact();
+const transact = useTransact();
 
 // We can undo this transaction, because "my-custom-origin" is tracked
 transact((tx) => {

--- a/apps/web/src/inputs/docs/@pluv_react/Presence.mdx
+++ b/apps/web/src/inputs/docs/@pluv_react/Presence.mdx
@@ -26,11 +26,11 @@ const { createRoomBundle } = createBundle(client);
 
 export const {
     PluvRoomProvider,
-    usePluvMyPresence,
-    usePluvMyself,
-    usePluvOther,
-    usePluvOthers,
-    usePluvStorage,
+    useMyPresence,
+    useMyself,
+    useOther,
+    useOthers,
+    useStorage,
 } = createRoomBundle({
     // Define the validation schema for presence, using zod
     presence: z.object({
@@ -65,13 +65,13 @@ const Room: FC = () => {
 ### Current user's presence
 
 ```tsx
-import { usePluvMyPresence, usePluvMyself } from "frontend/io";
+import { useMyPresence, useMyself } from "frontend/io";
 import { useCallback } from "react";
 
-const [myPresence, updateMyPresence] = usePluvMyPresence();
+const [myPresence, updateMyPresence] = useMyPresence();
 //     ^? const myPresence: { selectionId: string | null } | null
 
-const myself = usePluvMyself();
+const myself = useMyself();
 //    ^? const myself: {
 //        connectionId: string;
 //        presence: { selectionId: string | null };
@@ -87,9 +87,9 @@ const selectInput = useCallback((selectionId: string) => {
 ### Others' presence
 
 ```tsx
-import { usePluvOther, usePluvOthers } from "frontend/io";
+import { useOther, useOthers } from "frontend/io";
 
-const others = usePluvOthers();
+const others = useOthers();
 //    ^? const others: readonly {
 //        connectionId: string;
 //        presence: { selectionId: string | null };
@@ -98,7 +98,7 @@ const others = usePluvOthers();
 
 // const connectionId = others[0]?.connectionId!;
 
-const other = usePluvOther(connectionId);
+const other = useOther(connectionId);
 //    ^? const other: {
 //        connectionId: string;
 //        presence: { selectionId: string | null };

--- a/apps/web/src/inputs/docs/@pluv_react/Yjs Storage.mdx
+++ b/apps/web/src/inputs/docs/@pluv_react/Yjs Storage.mdx
@@ -25,7 +25,7 @@ const { createRoomBundle } = createBundle(client);
 
 export const {
     PluvRoomProvider,
-    usePluvStorage,
+    useStorage,
 } = createRoomBundle({
     // Set the initial storage value, and type here
     // Don't worry, we can set a different default value in the room component
@@ -60,14 +60,14 @@ export const MyPage: FC = () => {
 
 ## Use yjs shared-types
 
-We can then use [yjs shared-types](https://docs.yjs.dev/getting-started/working-with-shared-types) to leverage shared CRDTs between connected clients using `usePluvStorage`.
+We can then use [yjs shared-types](https://docs.yjs.dev/getting-started/working-with-shared-types) to leverage shared CRDTs between connected clients using `useStorage`.
 
 ```tsx
-import { usePluvStorage } from "frontend/io";
+import { useStorage } from "frontend/io";
 import { useCallback } from "react";
 
 // "messages" is a key from the root properties of `initialStorage`.
-const [messages, sharedType] = usePluvStorage("messages");
+const [messages, sharedType] = useStorage("messages");
 
 const addMessage = useCallback((message: string) => {
     sharedType.push([message]);

--- a/apps/web/src/inputs/docs/Ecosystem.mdx
+++ b/apps/web/src/inputs/docs/Ecosystem.mdx
@@ -45,7 +45,7 @@ const client = createClient<typeof io>();
 
 const { createRoomBundle } = createBundle(client);
 
-const { usePluvRoom } = createRoomBundle({
+const { useRoom } = createRoomBundle({
     addons: [addonIndexedDB({ enabled: true })],
         // Alternatively
     addons: [addonIndexedDB({ enabled: (room) => room.id === "my-room" })],

--- a/apps/web/src/pluv-io/cloudflare.ts
+++ b/apps/web/src/pluv-io/cloudflare.ts
@@ -15,7 +15,7 @@ export const {
     PluvProvider,
 
     // hooks
-    usePluvClient,
+    useClient,
 } = createBundle(client);
 
 export const {
@@ -24,15 +24,15 @@ export const {
     PluvRoomProvider,
 
     // hooks
-    usePluvBroadcast,
-    usePluvConnection,
-    usePluvEvent,
-    usePluvMyPresence,
-    usePluvMyself,
-    usePluvOther,
-    usePluvOthers,
-    usePluvRoom,
-    usePluvStorage,
+    useBroadcast,
+    useConnection,
+    useEvent,
+    useMyPresence,
+    useMyself,
+    useOther,
+    useOthers,
+    useRoom,
+    useStorage,
 } = createRoomBundle({
     presence: z.object({
         demoChessSquare: z.nullable(z.string()),

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -218,7 +218,7 @@
 
   ## @pluv/react
 
-  `@pluv/react`'s `createRoomBundle` now exposes 5 new react hooks: `usePluvCanRedo`, `usePluvCanUndo`, `usePluvRedo`, `usePluvUndo` and `usePluvTransact`.
+  `@pluv/react`'s `createRoomBundle` now exposes 5 new react hooks: `useCanRedo`, `useCanUndo`, `useRedo`, `useUndo` and `useTransact`.
 
   Refer to the code-example below to better understand how to undo and redo with your `createRoomBundle`.
 
@@ -231,12 +231,12 @@
   const { createRoomBundle } = createBundle(client);
 
   const {
-    usePluvCanRedo,
-    usePluvCanUndo,
-    usePluvRedo,
-    usePluvStorage,
-    usePluvTransact,
-    usePluvUndo,
+    useCanRedo,
+    useCanUndo,
+    useRedo,
+    useStorage,
+    useTransact,
+    useUndo,
   } = createRoomBundle({
     initialStorage: () => ({
       messages: y.array<string>([]),
@@ -264,13 +264,13 @@
   /**
    * @description Check whether calling undo will mutate storage
    */
-  const canUndo: boolean = usePluvCanUndo();
+  const canUndo: boolean = useCanUndo();
   /**
    * @description Check whether calling redo will mutate storage
    */
-  const canRedo: boolean = usePluvCanRedo();
+  const canRedo: boolean = useCanRedo();
 
-  const [messages, sharedType] = usePluvStorage("messages");
+  const [messages, sharedType] = useStorage("messages");
 
   /**
    * @description Calling transact will enable a storage mutation to be undone/redone.
@@ -279,7 +279,7 @@
    *
    * You can specify a 2nd parameter to transact with a different transaction origin.
    */
-  const transact = usePluvTransact();
+  const transact = useTransact();
 
   transact(() => {
     sharedType.push(["hello world!"]);
@@ -293,14 +293,14 @@
   /**
    * @description Undoes the last valid mutation to storage
    */
-  const undo = usePluvUndo();
+  const undo = useUndo();
 
   undo();
 
   /**
    * @description Re-applies the last undone mutation to storage
    */
-  const redo = usePluvRedo();
+  const redo = useRedo();
 
   redo();
   ```

--- a/packages/crdt-yjs/CHANGELOG.md
+++ b/packages/crdt-yjs/CHANGELOG.md
@@ -196,7 +196,7 @@
 
   ## @pluv/react
 
-  `@pluv/react`'s `createRoomBundle` now exposes 5 new react hooks: `usePluvCanRedo`, `usePluvCanUndo`, `usePluvRedo`, `usePluvUndo` and `usePluvTransact`.
+  `@pluv/react`'s `createRoomBundle` now exposes 5 new react hooks: `useCanRedo`, `useCanUndo`, `useRedo`, `useUndo` and `useTransact`.
 
   Refer to the code-example below to better understand how to undo and redo with your `createRoomBundle`.
 
@@ -209,12 +209,12 @@
   const { createRoomBundle } = createBundle(client);
 
   const {
-    usePluvCanRedo,
-    usePluvCanUndo,
-    usePluvRedo,
-    usePluvStorage,
-    usePluvTransact,
-    usePluvUndo,
+    useCanRedo,
+    useCanUndo,
+    useRedo,
+    useStorage,
+    useTransact,
+    useUndo,
   } = createRoomBundle({
     initialStorage: () => ({
       messages: y.array<string>([]),
@@ -242,13 +242,13 @@
   /**
    * @description Check whether calling undo will mutate storage
    */
-  const canUndo: boolean = usePluvCanUndo();
+  const canUndo: boolean = useCanUndo();
   /**
    * @description Check whether calling redo will mutate storage
    */
-  const canRedo: boolean = usePluvCanRedo();
+  const canRedo: boolean = useCanRedo();
 
-  const [messages, sharedType] = usePluvStorage("messages");
+  const [messages, sharedType] = useStorage("messages");
 
   /**
    * @description Calling transact will enable a storage mutation to be undone/redone.
@@ -257,7 +257,7 @@
    *
    * You can specify a 2nd parameter to transact with a different transaction origin.
    */
-  const transact = usePluvTransact();
+  const transact = useTransact();
 
   transact(() => {
     sharedType.push(["hello world!"]);
@@ -271,14 +271,14 @@
   /**
    * @description Undoes the last valid mutation to storage
    */
-  const undo = usePluvUndo();
+  const undo = useUndo();
 
   undo();
 
   /**
    * @description Re-applies the last undone mutation to storage
    */
-  const redo = usePluvRedo();
+  const redo = useRedo();
 
   redo();
   ```

--- a/packages/io/README.md
+++ b/packages/io/README.md
@@ -54,9 +54,9 @@ Pluv.IO allows you to build real-time collaborative features with a fully end-to
 So you can do this:
 
 ```tsx
-const broadcast = usePluvBroadcast();
+const broadcast = useBroadcast();
 
-usePluvEvent("RECEIVE_MESSAGE", ({ data }) => {
+useEvent("RECEIVE_MESSAGE", ({ data }) => {
   setMessages([...messages, data.message]);
 });
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -25,12 +25,12 @@
 
 ### Minor Changes
 
-- 4c4b47f: Added `usePluvDoc` to access the root Yjs doc.
+- 4c4b47f: Added `useDoc` to access the root Yjs doc.
 
   ```ts
   import type { Doc } from "yjs";
 
-  const doc: Doc = usePluvDoc();
+  const doc: Doc = useDoc();
   ```
 
 ### Patch Changes
@@ -216,7 +216,7 @@
 
   ## @pluv/react
 
-  `@pluv/react`'s `createRoomBundle` now exposes 5 new react hooks: `usePluvCanRedo`, `usePluvCanUndo`, `usePluvRedo`, `usePluvUndo` and `usePluvTransact`.
+  `@pluv/react`'s `createRoomBundle` now exposes 5 new react hooks: `useCanRedo`, `useCanUndo`, `useRedo`, `useUndo` and `useTransact`.
 
   Refer to the code-example below to better understand how to undo and redo with your `createRoomBundle`.
 
@@ -229,12 +229,12 @@
   const { createRoomBundle } = createBundle(client);
 
   const {
-    usePluvCanRedo,
-    usePluvCanUndo,
-    usePluvRedo,
-    usePluvStorage,
-    usePluvTransact,
-    usePluvUndo,
+    useCanRedo,
+    useCanUndo,
+    useRedo,
+    useStorage,
+    useTransact,
+    useUndo,
   } = createRoomBundle({
     initialStorage: () => ({
       messages: y.array<string>([]),
@@ -262,13 +262,13 @@
   /**
    * @description Check whether calling undo will mutate storage
    */
-  const canUndo: boolean = usePluvCanUndo();
+  const canUndo: boolean = useCanUndo();
   /**
    * @description Check whether calling redo will mutate storage
    */
-  const canRedo: boolean = usePluvCanRedo();
+  const canRedo: boolean = useCanRedo();
 
-  const [messages, sharedType] = usePluvStorage("messages");
+  const [messages, sharedType] = useStorage("messages");
 
   /**
    * @description Calling transact will enable a storage mutation to be undone/redone.
@@ -277,7 +277,7 @@
    *
    * You can specify a 2nd parameter to transact with a different transaction origin.
    */
-  const transact = usePluvTransact();
+  const transact = useTransact();
 
   transact(() => {
     sharedType.push(["hello world!"]);
@@ -291,14 +291,14 @@
   /**
    * @description Undoes the last valid mutation to storage
    */
-  const undo = usePluvUndo();
+  const undo = useUndo();
 
   undo();
 
   /**
    * @description Re-applies the last undone mutation to storage
    */
-  const redo = usePluvRedo();
+  const redo = useRedo();
 
   redo();
   ```

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -76,7 +76,7 @@ export const {
     PluvProvider,
 
     // hooks
-    usePluvClient,
+    useClient,
 } = createBundle(client);
 
 export const {
@@ -84,15 +84,15 @@ export const {
     PluvRoomProvider,
 
     // hooks
-    usePluvBroadcast,
-    usePluvConnection,
-    usePluvEvent,
-    usePluvMyPresence,
-    usePluvMyself,
-    usePluvOther,
-    usePluvOthers,
-    usePluvRoom,
-    usePluvStorage,
+    useBroadcast,
+    useConnection,
+    useEvent,
+    useMyPresence,
+    useMyself,
+    useOther,
+    useOthers,
+    useRoom,
+    useStorage,
 } = createRoomBundle({
     initialStorage: () => ({
         messages: y.array([
@@ -123,9 +123,9 @@ export const MyPage: FC<Record<string, never>> = () => {
 };
 
 export const MyRoom: FC<Record<string, never>> = () => {
-    const broadcast = usePluvBroadcast();
+    const broadcast = useBroadcast();
 
-    usePluvEvent("RECEIVE_MESSAGE", ({ data }) => {
+    useEvent("RECEIVE_MESSAGE", ({ data }) => {
         // data is typed as { message: string }
         console.log(data.message);
     });

--- a/packages/react/src/createBundle.tsx
+++ b/packages/react/src/createBundle.tsx
@@ -26,7 +26,7 @@ export interface CreateBundle<TIO extends IOLike> {
     PluvProvider: FC<PluvProviderProps>;
 
     // hooks
-    usePluvClient: () => PluvClient<TIO>;
+    useClient: () => PluvClient<TIO>;
 }
 
 export const createBundle = <TIO extends IOLike>(
@@ -53,7 +53,7 @@ export const createBundle = <TIO extends IOLike>(
 
     PluvProvider.displayName = "PluvProvider";
 
-    const usePluvClient = (): PluvClient<TIO> => useContext(PluvContext);
+    const useClient = (): PluvClient<TIO> => useContext(PluvContext);
 
     const createRoomBundle = <
         TPresence extends JsonObject = {},
@@ -66,6 +66,6 @@ export const createBundle = <TIO extends IOLike>(
     return {
         createRoomBundle,
         PluvProvider,
-        usePluvClient,
+        useClient,
     };
 };

--- a/packages/react/src/createRoomBundle.tsx
+++ b/packages/react/src/createRoomBundle.tsx
@@ -99,44 +99,44 @@ export interface CreateRoomBundle<
     PluvRoomProvider: FC<PluvRoomProviderProps<TIO, TPresence, TStorage>>;
 
     // hooks
-    usePluvBroadcast: () => <TEvent extends keyof InferIOInput<TIO>>(
+    useBroadcast: () => <TEvent extends keyof InferIOInput<TIO>>(
         event: TEvent,
         data: Id<InferIOInput<TIO>[TEvent]>,
     ) => void;
-    usePluvCanRedo: () => boolean;
-    usePluvCanUndo: () => boolean;
-    usePluvConnection: <T extends unknown = WebSocketConnection>(
+    useCanRedo: () => boolean;
+    useCanUndo: () => boolean;
+    useConnection: <T extends unknown = WebSocketConnection>(
         selector: (connection: WebSocketConnection) => T,
         options?: SubscriptionHookOptions<Id<T>>,
     ) => Id<T>;
-    usePluvDoc: () => AbstractCrdtDoc<TStorage>;
-    usePluvEvent: <TType extends keyof InferIOOutput<TIO>>(
+    useDoc: () => AbstractCrdtDoc<TStorage>;
+    useEvent: <TType extends keyof InferIOOutput<TIO>>(
         type: TType,
         callback: (data: Id<IOEventMessage<TIO, TType>>) => void,
     ) => void;
-    usePluvMyPresence: <T extends unknown = TPresence>(
+    useMyPresence: <T extends unknown = TPresence>(
         selector?: (myPresence: TPresence) => T,
         options?: SubscriptionHookOptions<Id<T> | null>,
     ) => [
         myPresence: Id<T>,
         updateMyPresence: Dispatch<UpdateMyPresenceAction<TPresence>>,
     ];
-    usePluvMyself: <T extends unknown = UserInfo<TIO, TPresence>>(
+    useMyself: <T extends unknown = UserInfo<TIO, TPresence>>(
         selector?: (myself: Id<UserInfo<TIO, TPresence>>) => T,
         options?: SubscriptionHookOptions<Id<T> | null>,
     ) => Id<T> | null;
-    usePluvOther: <T extends unknown = UserInfo<TIO, TPresence>>(
+    useOther: <T extends unknown = UserInfo<TIO, TPresence>>(
         connectionId: string,
         selector?: (other: UserInfo<TIO, TPresence>) => T,
         options?: SubscriptionHookOptions<Id<T> | null>,
     ) => Id<T> | null;
-    usePluvOthers: <T extends unknown = UserInfo<TIO, TPresence>>(
+    useOthers: <T extends unknown = UserInfo<TIO, TPresence>>(
         selector?: (other: readonly Id<UserInfo<TIO, TPresence>>[]) => T[],
         options?: SubscriptionHookOptions<readonly Id<T>[]>,
     ) => readonly Id<T>[];
-    usePluvRedo: () => () => void;
-    usePluvRoom: () => AbstractRoom<TIO, TPresence, TStorage>;
-    usePluvStorage: <
+    useRedo: () => () => void;
+    useRoom: () => AbstractRoom<TIO, TPresence, TStorage>;
+    useStorage: <
         TKey extends keyof TStorage,
         TData extends unknown = InferCrdtStorageJson<TStorage[TKey]>,
     >(
@@ -144,11 +144,11 @@ export interface CreateRoomBundle<
         selector?: (data: InferCrdtStorageJson<TStorage[TKey]>) => TData,
         options?: SubscriptionHookOptions<TData | null>,
     ) => [data: TData | null, sharedType: TStorage[TKey] | null];
-    usePluvTransact: () => (
+    useTransact: () => (
         fn: (storage: TStorage) => void,
         origin?: string,
     ) => void;
-    usePluvUndo: () => () => void;
+    useUndo: () => () => void;
 }
 
 export const createRoomBundle = <
@@ -261,13 +261,13 @@ export const createRoomBundle = <
 
     PluvRoomProvider.displayName = "PluvRoomProvider";
 
-    const usePluvRoom = () => useContext(PluvRoomContext);
+    const useRoom = () => useContext(PluvRoomContext);
 
-    const usePluvBroadcast = (): (<TEvent extends keyof InferIOInput<TIO>>(
+    const useBroadcast = (): (<TEvent extends keyof InferIOInput<TIO>>(
         event: TEvent,
         data: Id<InferIOInput<TIO>[TEvent]>,
     ) => void) => {
-        const room = usePluvRoom();
+        const room = useRoom();
 
         return useCallback(
             <TEvent extends keyof InferIOInput<TIO>>(
@@ -280,8 +280,8 @@ export const createRoomBundle = <
         );
     };
 
-    const usePluvCanRedo = (): boolean => {
-        const room = usePluvRoom();
+    const useCanRedo = (): boolean => {
+        const room = useRoom();
 
         const subscribe = useCallback(
             (onStoreChange: () => void) => room.storageRoot(onStoreChange),
@@ -300,8 +300,8 @@ export const createRoomBundle = <
         return canRedo;
     };
 
-    const usePluvCanUndo = (): boolean => {
-        const room = usePluvRoom();
+    const useCanUndo = (): boolean => {
+        const room = useRoom();
 
         const subscribe = useCallback(
             (onStoreChange: () => void) => room.storageRoot(onStoreChange),
@@ -320,11 +320,11 @@ export const createRoomBundle = <
         return canRedo;
     };
 
-    const usePluvConnection = <T extends unknown = WebSocketConnection>(
+    const useConnection = <T extends unknown = WebSocketConnection>(
         selector = identity as (connection: WebSocketConnection) => T,
         options?: SubscriptionHookOptions<Id<T>>,
     ): Id<T> => {
-        const room = usePluvRoom();
+        const room = useRoom();
 
         const subscribe = useCallback(
             (onStoreChange: () => void) => {
@@ -349,17 +349,17 @@ export const createRoomBundle = <
         );
     };
 
-    const usePluvDoc = () => {
-        const room = usePluvRoom();
+    const useDoc = () => {
+        const room = useRoom();
 
         return room.getDoc();
     };
 
-    const usePluvEvent = <TType extends keyof InferIOOutput<TIO>>(
+    const useEvent = <TType extends keyof InferIOOutput<TIO>>(
         type: TType,
         callback: (data: Id<IOEventMessage<TIO, TType>>) => void,
     ): void => {
-        const room = usePluvRoom();
+        const room = useRoom();
 
         useEffect(() => {
             const unsubscribe = room.event(type, callback);
@@ -370,11 +370,11 @@ export const createRoomBundle = <
         }, [callback, room, type]);
     };
 
-    const usePluvMyPresence = <T extends unknown = TPresence>(
+    const useMyPresence = <T extends unknown = TPresence>(
         selector = identity as (myPresence: TPresence) => T,
         options?: SubscriptionHookOptions<Id<T> | null>,
     ): [Id<T>, Dispatch<UpdateMyPresenceAction<TPresence>>] => {
-        const room = usePluvRoom();
+        const room = useRoom();
 
         const subscribe = useCallback(
             (onStoreChange: () => void) => {
@@ -414,11 +414,11 @@ export const createRoomBundle = <
         return [myPresence, updateMyPresence];
     };
 
-    const usePluvMyself = <T extends unknown = UserInfo<TIO, TPresence>>(
+    const useMyself = <T extends unknown = UserInfo<TIO, TPresence>>(
         selector = identity as (myself: Id<UserInfo<TIO, TPresence>>) => T,
         options?: SubscriptionHookOptions<Id<T> | null>,
     ): Id<T> | null => {
-        const room = usePluvRoom();
+        const room = useRoom();
 
         const subscribe = useCallback(
             (onStoreChange: () => void) => {
@@ -445,12 +445,12 @@ export const createRoomBundle = <
         );
     };
 
-    const usePluvOther = <T extends unknown = UserInfo<TIO, TPresence>>(
+    const useOther = <T extends unknown = UserInfo<TIO, TPresence>>(
         connectionId: string,
         selector = identity as (other: UserInfo<TIO, TPresence>) => T,
         options?: SubscriptionHookOptions<Id<T> | null>,
     ): Id<T> | null => {
-        const room = usePluvRoom();
+        const room = useRoom();
 
         const subscribe = useCallback(
             (onStoreChange: () => void) => {
@@ -480,13 +480,13 @@ export const createRoomBundle = <
         );
     };
 
-    const usePluvOthers = <T extends unknown = UserInfo<TIO, TPresence>>(
+    const useOthers = <T extends unknown = UserInfo<TIO, TPresence>>(
         selector = identity as (
             other: readonly Id<UserInfo<TIO, TPresence>>[],
         ) => T[],
         options?: SubscriptionHookOptions<readonly Id<T>[]>,
     ): readonly Id<T>[] => {
-        const room = usePluvRoom();
+        const room = useRoom();
 
         const subscribe = useCallback(
             (onStoreChange: () => void) => {
@@ -508,13 +508,13 @@ export const createRoomBundle = <
         );
     };
 
-    const usePluvRedo = () => {
-        const room = usePluvRoom();
+    const useRedo = () => {
+        const room = useRoom();
 
         return room.redo;
     };
 
-    const usePluvStorage = <
+    const useStorage = <
         TKey extends keyof TStorage,
         TData extends unknown = InferCrdtStorageJson<TStorage[TKey]>,
     >(
@@ -524,7 +524,7 @@ export const createRoomBundle = <
         ) => TData,
         options?: SubscriptionHookOptions<TData | null>,
     ): [data: TData | null, sharedType: TStorage[TKey] | null] => {
-        const room = usePluvRoom();
+        const room = useRoom();
         const rerender = useRerender();
 
         room.subscribe("storage-loaded", () => {
@@ -562,14 +562,14 @@ export const createRoomBundle = <
         return [data, sharedType];
     };
 
-    const usePluvTransact = () => {
-        const room = usePluvRoom();
+    const useTransact = () => {
+        const room = useRoom();
 
         return room.transact;
     };
 
-    const usePluvUndo = () => {
-        const room = usePluvRoom();
+    const useUndo = () => {
+        const room = useRoom();
 
         return room.undo;
     };
@@ -580,20 +580,20 @@ export const createRoomBundle = <
         PluvRoomProvider,
 
         // hooks
-        usePluvBroadcast,
-        usePluvCanRedo,
-        usePluvCanUndo,
-        usePluvConnection,
-        usePluvDoc,
-        usePluvEvent,
-        usePluvMyPresence,
-        usePluvMyself,
-        usePluvOther,
-        usePluvOthers,
-        usePluvRedo,
-        usePluvRoom,
-        usePluvStorage,
-        usePluvTransact,
-        usePluvUndo,
+        useBroadcast,
+        useCanRedo,
+        useCanUndo,
+        useConnection,
+        useDoc,
+        useEvent,
+        useMyPresence,
+        useMyself,
+        useOther,
+        useOthers,
+        useRedo,
+        useRoom,
+        useStorage,
+        useTransact,
+        useUndo,
     };
 };

--- a/tests/e2e/src/components/loro/node/PresenceRoom.tsx
+++ b/tests/e2e/src/components/loro/node/PresenceRoom.tsx
@@ -1,16 +1,16 @@
 import type { FC } from "react";
 import {
-    usePluvMyPresence,
-    usePluvMyself,
-    usePluvOthers,
+    useMyPresence,
+    useMyself,
+    useOthers,
 } from "../../../pluv-io/loro/node";
 
 export type PresenceRoomProps = Record<string, never>;
 
 export const PresenceRoom: FC<PresenceRoomProps> = () => {
-    const myself = usePluvMyself();
-    const [myPresence, updateMyPresence] = usePluvMyPresence();
-    const others = usePluvOthers();
+    const myself = useMyself();
+    const [myPresence, updateMyPresence] = useMyPresence();
+    const others = useOthers();
 
     if (!myself) return null;
 

--- a/tests/e2e/src/components/loro/node/StorageRoom.tsx
+++ b/tests/e2e/src/components/loro/node/StorageRoom.tsx
@@ -1,25 +1,25 @@
 import { loro } from "@pluv/crdt-loro";
 import type { FC } from "react";
 import {
-    usePluvCanRedo,
-    usePluvCanUndo,
-    usePluvRedo,
-    usePluvStorage,
-    usePluvTransact,
-    usePluvUndo,
+    useCanRedo,
+    useCanUndo,
+    useRedo,
+    useStorage,
+    useTransact,
+    useUndo,
 } from "../../../pluv-io/loro/node";
 
 export type StorageRoomProps = Record<string, never>;
 
 export const StorageRoom: FC<StorageRoomProps> = () => {
-    const [messages, sharedType] = usePluvStorage("messages");
+    const [messages, sharedType] = useStorage("messages");
 
-    const canUndo = usePluvCanUndo();
-    const canRedo = usePluvCanRedo();
-    const transact = usePluvTransact();
+    const canUndo = useCanUndo();
+    const canRedo = useCanRedo();
+    const transact = useTransact();
 
-    const undo = usePluvUndo();
-    const redo = usePluvRedo();
+    const undo = useUndo();
+    const redo = useRedo();
 
     return (
         <div id="storage-room">

--- a/tests/e2e/src/components/yjs/cloudflare/PresenceRoom.tsx
+++ b/tests/e2e/src/components/yjs/cloudflare/PresenceRoom.tsx
@@ -1,16 +1,16 @@
 import type { FC } from "react";
 import {
-    usePluvMyPresence,
-    usePluvMyself,
-    usePluvOthers,
+    useMyPresence,
+    useMyself,
+    useOthers,
 } from "../../../pluv-io/yjs/cloudflare";
 
 export type PresenceRoomProps = Record<string, never>;
 
 export const PresenceRoom: FC<PresenceRoomProps> = () => {
-    const myself = usePluvMyself();
-    const [myPresence, updateMyPresence] = usePluvMyPresence();
-    const others = usePluvOthers();
+    const myself = useMyself();
+    const [myPresence, updateMyPresence] = useMyPresence();
+    const others = useOthers();
 
     if (!myself) return null;
 

--- a/tests/e2e/src/components/yjs/cloudflare/StorageRoom.tsx
+++ b/tests/e2e/src/components/yjs/cloudflare/StorageRoom.tsx
@@ -1,25 +1,25 @@
 import { yjs } from "@pluv/crdt-yjs";
 import type { FC } from "react";
 import {
-    usePluvCanRedo,
-    usePluvCanUndo,
-    usePluvRedo,
-    usePluvStorage,
-    usePluvTransact,
-    usePluvUndo,
+    useCanRedo,
+    useCanUndo,
+    useRedo,
+    useStorage,
+    useTransact,
+    useUndo,
 } from "../../../pluv-io/yjs/cloudflare";
 
 export type StorageRoomProps = Record<string, never>;
 
 export const StorageRoom: FC<StorageRoomProps> = () => {
-    const [messages, sharedType] = usePluvStorage("messages");
+    const [messages, sharedType] = useStorage("messages");
 
-    const canUndo = usePluvCanUndo();
-    const canRedo = usePluvCanRedo();
-    const transact = usePluvTransact();
+    const canUndo = useCanUndo();
+    const canRedo = useCanRedo();
+    const transact = useTransact();
 
-    const undo = usePluvUndo();
-    const redo = usePluvRedo();
+    const undo = useUndo();
+    const redo = useRedo();
 
     return (
         <div id="storage-room">

--- a/tests/e2e/src/components/yjs/node-redis/PresenceRoom.tsx
+++ b/tests/e2e/src/components/yjs/node-redis/PresenceRoom.tsx
@@ -1,16 +1,16 @@
 import type { FC } from "react";
 import {
-    usePluvMyPresence,
-    usePluvMyself,
-    usePluvOthers,
+    useMyPresence,
+    useMyself,
+    useOthers,
 } from "../../../pluv-io/yjs/node-redis";
 
 export type PresenceRoomProps = Record<string, never>;
 
 export const PresenceRoom: FC<PresenceRoomProps> = () => {
-    const myself = usePluvMyself();
-    const [myPresence, updateMyPresence] = usePluvMyPresence();
-    const others = usePluvOthers();
+    const myself = useMyself();
+    const [myPresence, updateMyPresence] = useMyPresence();
+    const others = useOthers();
 
     if (!myself) return null;
 

--- a/tests/e2e/src/components/yjs/node-redis/StorageRoom.tsx
+++ b/tests/e2e/src/components/yjs/node-redis/StorageRoom.tsx
@@ -1,25 +1,25 @@
 import { yjs } from "@pluv/crdt-yjs";
 import type { FC } from "react";
 import {
-    usePluvCanRedo,
-    usePluvCanUndo,
-    usePluvRedo,
-    usePluvStorage,
-    usePluvTransact,
-    usePluvUndo,
+    useCanRedo,
+    useCanUndo,
+    useRedo,
+    useStorage,
+    useTransact,
+    useUndo,
 } from "../../../pluv-io/yjs/node-redis";
 
 export type StorageRoomProps = Record<string, never>;
 
 export const StorageRoom: FC<StorageRoomProps> = () => {
-    const [messages, sharedType] = usePluvStorage("messages");
+    const [messages, sharedType] = useStorage("messages");
 
-    const canUndo = usePluvCanUndo();
-    const canRedo = usePluvCanRedo();
-    const transact = usePluvTransact();
+    const canUndo = useCanUndo();
+    const canRedo = useCanRedo();
+    const transact = useTransact();
 
-    const undo = usePluvUndo();
-    const redo = usePluvRedo();
+    const undo = useUndo();
+    const redo = useRedo();
 
     return (
         <div id="storage-room">

--- a/tests/e2e/src/components/yjs/node/PresenceRoom.tsx
+++ b/tests/e2e/src/components/yjs/node/PresenceRoom.tsx
@@ -1,16 +1,16 @@
 import type { FC } from "react";
 import {
-    usePluvMyPresence,
-    usePluvMyself,
-    usePluvOthers,
+    useMyPresence,
+    useMyself,
+    useOthers,
 } from "../../../pluv-io/yjs/node";
 
 export type PresenceRoomProps = Record<string, never>;
 
 export const PresenceRoom: FC<PresenceRoomProps> = () => {
-    const myself = usePluvMyself();
-    const [myPresence, updateMyPresence] = usePluvMyPresence();
-    const others = usePluvOthers();
+    const myself = useMyself();
+    const [myPresence, updateMyPresence] = useMyPresence();
+    const others = useOthers();
 
     if (!myself) return null;
 

--- a/tests/e2e/src/components/yjs/node/StorageRoom.tsx
+++ b/tests/e2e/src/components/yjs/node/StorageRoom.tsx
@@ -1,25 +1,25 @@
 import { yjs } from "@pluv/crdt-yjs";
 import type { FC } from "react";
 import {
-    usePluvCanRedo,
-    usePluvCanUndo,
-    usePluvRedo,
-    usePluvStorage,
-    usePluvTransact,
-    usePluvUndo,
+    useCanRedo,
+    useCanUndo,
+    useRedo,
+    useStorage,
+    useTransact,
+    useUndo,
 } from "../../../pluv-io/yjs/node";
 
 export type StorageRoomProps = Record<string, never>;
 
 export const StorageRoom: FC<StorageRoomProps> = () => {
-    const [messages, sharedType] = usePluvStorage("messages");
+    const [messages, sharedType] = useStorage("messages");
 
-    const canUndo = usePluvCanUndo();
-    const canRedo = usePluvCanRedo();
-    const transact = usePluvTransact();
+    const canUndo = useCanUndo();
+    const canRedo = useCanRedo();
+    const transact = useTransact();
 
-    const undo = usePluvUndo();
-    const redo = usePluvRedo();
+    const undo = useUndo();
+    const redo = useRedo();
 
     return (
         <div id="storage-room">

--- a/tests/e2e/src/demo/ChatRoom.tsx
+++ b/tests/e2e/src/demo/ChatRoom.tsx
@@ -1,11 +1,11 @@
 import { FC, useCallback, useState } from "react";
-import { usePluvBroadcast, usePluvEvent } from "./pluv";
+import { useBroadcast, useEvent } from "./pluv";
 
 export const ChatRoom: FC<Record<string, never>> = () => {
     const [messages, setMessages] = useState<readonly string[]>([]);
-    const broadcast = usePluvBroadcast();
+    const broadcast = useBroadcast();
 
-    usePluvEvent("RECEIVE_MESSAGE", ({ data }) => {
+    useEvent("RECEIVE_MESSAGE", ({ data }) => {
         setMessages((oldMessages) => [...oldMessages, data.message]);
     });
 

--- a/tests/e2e/src/demo/pluv.ts
+++ b/tests/e2e/src/demo/pluv.ts
@@ -9,7 +9,7 @@ const client = createClient<typeof io>({
 
 export const { createRoomBundle } = createBundle(client);
 
-export const { usePluvBroadcast, usePluvEvent, usePluvMyself } =
+export const { useBroadcast, useEvent, useMyself } =
     createRoomBundle({
         initialStorage: yjs.doc(),
     });

--- a/tests/e2e/src/pluv-io/loro/node.ts
+++ b/tests/e2e/src/pluv-io/loro/node.ts
@@ -20,7 +20,7 @@ export const {
     PluvProvider,
 
     // hooks
-    usePluvClient,
+    useClient,
 } = createBundle(client);
 
 export const {
@@ -28,20 +28,20 @@ export const {
     PluvRoomProvider,
 
     // hooks
-    usePluvBroadcast,
-    usePluvCanRedo,
-    usePluvCanUndo,
-    usePluvConnection,
-    usePluvEvent,
-    usePluvMyPresence,
-    usePluvMyself,
-    usePluvOther,
-    usePluvOthers,
-    usePluvRedo,
-    usePluvRoom,
-    usePluvStorage,
-    usePluvTransact,
-    usePluvUndo,
+    useBroadcast,
+    useCanRedo,
+    useCanUndo,
+    useConnection,
+    useEvent,
+    useMyPresence,
+    useMyself,
+    useOther,
+    useOthers,
+    useRedo,
+    useRoom,
+    useStorage,
+    useTransact,
+    useUndo,
 } = createRoomBundle({
     initialStorage: loro.doc(() => ({
         messages: loro.array([

--- a/tests/e2e/src/pluv-io/yjs/cloudflare.ts
+++ b/tests/e2e/src/pluv-io/yjs/cloudflare.ts
@@ -20,7 +20,7 @@ export const {
     PluvProvider,
 
     // hooks
-    usePluvClient,
+    useClient,
 } = createBundle(client);
 
 export const {
@@ -28,20 +28,20 @@ export const {
     PluvRoomProvider,
 
     // hooks
-    usePluvBroadcast,
-    usePluvCanRedo,
-    usePluvCanUndo,
-    usePluvConnection,
-    usePluvEvent,
-    usePluvMyPresence,
-    usePluvMyself,
-    usePluvOther,
-    usePluvOthers,
-    usePluvRedo,
-    usePluvRoom,
-    usePluvStorage,
-    usePluvTransact,
-    usePluvUndo,
+    useBroadcast,
+    useCanRedo,
+    useCanUndo,
+    useConnection,
+    useEvent,
+    useMyPresence,
+    useMyself,
+    useOther,
+    useOthers,
+    useRedo,
+    useRoom,
+    useStorage,
+    useTransact,
+    useUndo,
 } = createRoomBundle({
     initialStorage: yjs.doc(() => ({
         messages: yjs.array([

--- a/tests/e2e/src/pluv-io/yjs/node-redis.ts
+++ b/tests/e2e/src/pluv-io/yjs/node-redis.ts
@@ -28,7 +28,7 @@ export const {
     PluvProvider,
 
     // hooks
-    usePluvClient,
+    useClient,
 } = createBundle(client);
 
 export const {
@@ -36,20 +36,20 @@ export const {
     PluvRoomProvider,
 
     // hooks
-    usePluvBroadcast,
-    usePluvCanRedo,
-    usePluvCanUndo,
-    usePluvConnection,
-    usePluvEvent,
-    usePluvMyPresence,
-    usePluvMyself,
-    usePluvOther,
-    usePluvOthers,
-    usePluvRedo,
-    usePluvRoom,
-    usePluvStorage,
-    usePluvTransact,
-    usePluvUndo,
+    useBroadcast,
+    useCanRedo,
+    useCanUndo,
+    useConnection,
+    useEvent,
+    useMyPresence,
+    useMyself,
+    useOther,
+    useOthers,
+    useRedo,
+    useRoom,
+    useStorage,
+    useTransact,
+    useUndo,
 } = createRoomBundle({
     initialStorage: yjs.doc(() => ({
         messages: yjs.array([

--- a/tests/e2e/src/pluv-io/yjs/node.ts
+++ b/tests/e2e/src/pluv-io/yjs/node.ts
@@ -21,7 +21,7 @@ export const {
     PluvProvider,
 
     // hooks
-    usePluvClient,
+    useClient,
 } = createBundle(client);
 
 export const {
@@ -29,20 +29,20 @@ export const {
     PluvRoomProvider,
 
     // hooks
-    usePluvBroadcast,
-    usePluvCanRedo,
-    usePluvCanUndo,
-    usePluvConnection,
-    usePluvEvent,
-    usePluvMyPresence,
-    usePluvMyself,
-    usePluvOther,
-    usePluvOthers,
-    usePluvRedo,
-    usePluvRoom,
-    usePluvStorage,
-    usePluvTransact,
-    usePluvUndo,
+    useBroadcast,
+    useCanRedo,
+    useCanUndo,
+    useConnection,
+    useEvent,
+    useMyPresence,
+    useMyself,
+    useOther,
+    useOthers,
+    useRedo,
+    useRoom,
+    useStorage,
+    useTransact,
+    useUndo,
 } = createRoomBundle({
     addons: [
         addonIndexedDB({


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Renamed all hooks from `@pluv/react` to be simply prefixed with `use` instead of `usePluv` (e.g. `usePluvStorage` is now just `useStorage`).