### PR TITLE
feat(io): move version to pluv io

### DIFF
--- a/.changeset/cold-rockets-trade.md
+++ b/.changeset/cold-rockets-trade.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": patch
+---
+
+Moved exposed `@pluv/io` version on the `PluvIO` instance as a property.

--- a/packages/io/src/PluvIO.ts
+++ b/packages/io/src/PluvIO.ts
@@ -26,6 +26,7 @@ import { IORoom } from "./IORoom";
 import type { JWTEncodeParams } from "./authorize";
 import { authorize } from "./authorize";
 import type { EventConfig, InferEventConfig } from "./types";
+import { __PLUV_VERSION } from "./version";
 
 type InferIOContext<TIO extends PluvIO<any, any, any, any, any, any, any>> =
     TIO extends PluvIO<any, any, infer IContext, any, any, any, any>
@@ -281,6 +282,7 @@ export class PluvIO<
     readonly _getInitialStorage: GetInitialStorageFn<TPlatform> | null = null;
     readonly _listeners: PluvIOListeners<TPlatform>;
     readonly _platform: TPlatform;
+    readonly _version: string = __PLUV_VERSION as any;
 
     constructor(
         options: PluvIOConfig<

--- a/packages/io/src/index.ts
+++ b/packages/io/src/index.ts
@@ -37,4 +37,3 @@ export type {
 } from "./authorize";
 export { createIO } from "./createIO";
 export type { CreateIOParams } from "./createIO";
-export { __PLUV_VERSION } from "./version";


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [ ] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Moved exposed installed version of `@pluv/io` to the `PluvIO` instance.