### PR TITLE
feat(io): narrow type of user on io session

### DIFF
--- a/.changeset/lucky-humans-help.md
+++ b/.changeset/lucky-humans-help.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": minor
+---
+
+Narrowed types for `user` within the session object of an event resolver.

--- a/packages/io/src/AbstractWebSocket.ts
+++ b/packages/io/src/AbstractWebSocket.ts
@@ -28,7 +28,7 @@ export type EventType = keyof AbstractEventMap;
 export interface AbstractWebSocketHandleErrorParams {
     error: unknown;
     message?: string;
-    session?: WebSocketSession;
+    session?: WebSocketSession<any>;
 }
 
 export type AbstractListener<TType extends keyof AbstractEventMap> = (

--- a/packages/io/src/PluvIO.ts
+++ b/packages/io/src/PluvIO.ts
@@ -285,7 +285,7 @@ export class PluvIO<
         TResultSync extends EventRecord<string, any> = {},
     >(
         event: TEvent,
-        config: EventConfig<TPlatform, TContext, TData, TResultBroadcast, TResultSelf, TResultSync>,
+        config: EventConfig<TPlatform, TAuthorize, TContext, TData, TResultBroadcast, TResultSelf, TResultSync>,
     ): PluvIO<
         TPlatform,
         TAuthorize,

--- a/packages/io/src/PluvIO.ts
+++ b/packages/io/src/PluvIO.ts
@@ -17,7 +17,7 @@ import type {
     Spread,
 } from "@pluv/types";
 import colors from "kleur";
-import type { AbstractPlatform, InferPlatformEventContextType, InferPlatformRoomContextType } from "./AbstractPlatform";
+import type { AbstractPlatform, InferPlatformRoomContextType } from "./AbstractPlatform";
 import type { IORoomListenerEvent } from "./IORoom";
 import { IORoom } from "./IORoom";
 import type { JWTEncodeParams } from "./authorize";
@@ -59,7 +59,7 @@ export interface PluvIOListeners<TPlatform extends AbstractPlatform> {
 
 export type PluvIOConfig<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends IOAuthorize<any, any, InferPlatformRoomContextType<TPlatform>> | null = null,
+    TAuthorize extends IOAuthorize<any, any, InferPlatformRoomContextType<TPlatform>> = BaseIOAuthorize,
     TContext extends JsonObject = {},
     TInput extends EventRecord<string, any> = {},
     TOutputBroadcast extends EventRecord<string, any> = {},
@@ -70,7 +70,7 @@ export type PluvIOConfig<
     context?: TContext;
     crdt?: { doc: (value: any) => AbstractCrdtDocFactory<any> };
     debug?: boolean;
-    events?: InferEventConfig<TPlatform, TContext, TInput, TOutputBroadcast, TOutputSelf, TOutputSync>;
+    events?: InferEventConfig<TPlatform, TAuthorize, TContext, TInput, TOutputBroadcast, TOutputSelf, TOutputSync>;
     getInitialStorage?: GetInitialStorageFn<TPlatform>;
     platform: TPlatform;
 };
@@ -98,7 +98,15 @@ export class PluvIO<
     readonly _context: TContext = {} as TContext;
     readonly _crdt: { doc: (value: any) => AbstractCrdtDocFactory<any> };
     readonly _debug: boolean;
-    readonly _events: InferEventConfig<TPlatform, TContext, TInput, TOutputBroadcast, TOutputSelf, TOutputSync> = {
+    readonly _events: InferEventConfig<
+        TPlatform,
+        TAuthorize,
+        TContext,
+        TInput,
+        TOutputBroadcast,
+        TOutputSelf,
+        TOutputSync
+    > = {
         $GET_OTHERS: {
             resolver: {
                 sync: (data, { room, session, sessions }) => {
@@ -215,7 +223,7 @@ export class PluvIO<
                 return { $STORAGE_UPDATED: { state: encodedState } };
             },
         },
-    } as InferEventConfig<TPlatform, TContext, TInput, TOutputBroadcast, TOutputSelf, TOutputSync>;
+    } as InferEventConfig<TPlatform, TAuthorize, TContext, TInput, TOutputBroadcast, TOutputSelf, TOutputSync>;
     readonly _getInitialStorage: GetInitialStorageFn<TPlatform> | null = null;
     readonly _listeners: PluvIOListeners<TPlatform>;
     readonly _platform: TPlatform;
@@ -295,6 +303,7 @@ export class PluvIO<
             [event]: config,
         } as InferEventConfig<
             TPlatform,
+            TAuthorize,
             TContext,
             EventRecord<TEvent, TData>,
             TResultBroadcast extends EventRecord<string, any> ? TResultBroadcast : {},


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [ ] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Narrow the type of `user` on `WebsocketSession` in `@pluv/io`.