### PR TITLE
feat(react): update use others return type

### DIFF
--- a/.changeset/moody-ties-double.md
+++ b/.changeset/moody-ties-double.md
@@ -1,0 +1,5 @@
+---
+"@pluv/react": minor
+---
+
+**Breaking**: useOthers now allows returning any data besides arrays when using a custom selector.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,16 +26,17 @@
 		"@pluv/client": "workspace:^",
 		"@pluv/crdt": "workspace:^",
 		"@pluv/types": "workspace:^",
-		"@types/react": "^18.3.3",
 		"@types/use-sync-external-store": "^0.0.6",
 		"fast-deep-equal": "^3.1.3",
 		"use-sync-external-store": "^1.2.2"
 	},
 	"peerDependencies": {
+		"@types/react": "^17.0.0 || ^18.0.0",
 		"react": "^17.0.0 || ^18.0.0"
 	},
 	"devDependencies": {
 		"@pluv/tsconfig": "workspace:^",
+		"@types/react": "^18.3.3",
 		"eslint": "^8.57.0",
 		"eslint-config-pluv": "workspace:^",
 		"react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1387,9 +1387,6 @@ importers:
       '@pluv/types':
         specifier: workspace:^
         version: link:../types
-      '@types/react':
-        specifier: ^18.3.3
-        version: 18.3.3
       '@types/use-sync-external-store':
         specifier: ^0.0.6
         version: 0.0.6
@@ -1403,6 +1400,9 @@ importers:
       '@pluv/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
+      '@types/react':
+        specifier: ^18.3.3
+        version: 18.3.3
       eslint:
         specifier: ^8.57.0
         version: 8.57.0


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

`useOthers` has been updated to allow returning non-array values when using a custom selector.