### PR TITLE
feat(io): move sessionId to websocket instead of IORoom

### DIFF
--- a/apps/server-cloudflare/src/index.ts
+++ b/apps/server-cloudflare/src/index.ts
@@ -3,7 +3,7 @@ import { ioServer } from "./pluv-io";
 
 export { ioServer } from "./pluv-io";
 
-const CORS_VALID_DOMAINS = ["pluv.io", "pluv.vercel.app"];
+const CORS_VALID_DOMAINS = ["pluv.io", "pluv.vercel.app"] as const;
 const CORS_MAX_AGE = 86_400;
 
 const Pluv = createPluvHandler({

--- a/packages/io/src/AbstractWebSocket.ts
+++ b/packages/io/src/AbstractWebSocket.ts
@@ -37,7 +37,6 @@ export type AbstractListener<TType extends keyof AbstractEventMap> = (
 
 export interface AbstractWebSocketConfig {
     room: string;
-    sessionId: string;
     userId: string | null;
 }
 
@@ -52,15 +51,14 @@ export abstract class AbstractWebSocket {
     public readonly CLOSED = 3;
 
     public room: string;
-    public sessionId: string;
 
     public abstract get readyState(): 0 | 1 | 2 | 3;
+    public abstract get sessionId(): string;
 
     constructor(config: AbstractWebSocketConfig) {
-        const { room, sessionId } = config;
+        const { room } = config;
 
         this.room = room;
-        this.sessionId = sessionId;
     }
 
     /**

--- a/packages/platform-cloudflare/src/CloudflareWebSocket.ts
+++ b/packages/platform-cloudflare/src/CloudflareWebSocket.ts
@@ -16,10 +16,19 @@ export class CloudflareWebSocket extends AbstractWebSocket {
         return this.webSocket.readyState as 0 | 1 | 2 | 3;
     }
 
-    constructor(webSocket: WebSocket, config: CloudflareWebSocketConfig) {
-        const { room, sessionId, userId } = config;
+    public get sessionId(): string {
+        const deserialized = this.webSocket.deserializeAttachment() ?? {};
+        const sessionId = deserialized.sessionId ?? crypto.randomUUID();
 
-        super({ room, sessionId, userId });
+        this.webSocket.serializeAttachment({ ...deserialized, sessionId });
+
+        return sessionId;
+    }
+
+    constructor(webSocket: WebSocket, config: CloudflareWebSocketConfig) {
+        const { room, userId } = config;
+
+        super({ room, userId });
 
         this.webSocket = webSocket;
     }

--- a/packages/platform-node/src/NodePlatform.ts
+++ b/packages/platform-node/src/NodePlatform.ts
@@ -1,8 +1,8 @@
 import type { AbstractPersistance, ConvertWebSocketConfig } from "@pluv/io";
 import { AbstractPlatform, AbstractPubSub } from "@pluv/io";
-import crypto from "crypto";
-import { IncomingMessage } from "http";
-import { TextDecoder } from "util";
+import crypto from "node:crypto";
+import { IncomingMessage } from "node:http";
+import { TextDecoder } from "node:util";
 import type { WebSocket } from "ws";
 import { NodeWebSocket } from "./NodeWebSocket";
 

--- a/packages/platform-node/src/NodeWebSocket.ts
+++ b/packages/platform-node/src/NodeWebSocket.ts
@@ -7,6 +7,7 @@ import type {
     AbstractWebSocketConfig,
 } from "@pluv/io";
 import { AbstractWebSocket } from "@pluv/io";
+import crypto from "node:crypto";
 import type { WebSocket } from "ws";
 
 export interface NodeWebSocketEventMap {
@@ -18,17 +19,24 @@ export interface NodeWebSocketEventMap {
 export type NodeWebSocketConfig = AbstractWebSocketConfig;
 
 export class NodeWebSocket extends AbstractWebSocket {
+    private _sessionId: string;
+
     public webSocket: WebSocket;
 
     public get readyState(): 0 | 1 | 2 | 3 {
         return this.webSocket.readyState;
     }
 
+    public get sessionId(): string {
+        return this._sessionId;
+    }
+
     constructor(webSocket: WebSocket, config: NodeWebSocketConfig) {
-        const { room, sessionId, userId } = config;
+        const { room, userId } = config;
 
-        super({ room, sessionId, userId });
+        super({ room, userId });
 
+        this._sessionId = crypto.randomUUID();
         this.webSocket = webSocket;
     }
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Move session id to AbstractWebsocket from IORoom.