### PR TITLE
feat(platform-cloudflare): support websocket hibernation

### DIFF
--- a/.changeset/blue-lobsters-argue.md
+++ b/.changeset/blue-lobsters-argue.md
@@ -1,0 +1,24 @@
+---
+"@pluv/platform-cloudflare": minor
+"@pluv/io": minor
+---
+
+`@pluv/platform-cloudflare` now supports Cloudflare Worker's WebSocket Hibernation API, and usees it by default.
+
+To switch back to not using the WebSocket Hibernation API, specify a `mode` of `attached`.
+
+```ts
+// With event-listeners directly attached to the websocket on registration (i.e. non-hibernation)
+createIO({
+    platform: platformCloudflare({
+        mode: "attached",
+    }),
+});
+
+// With event listeners unattached to the websocket during registration (i.e. hibernation)
+createIO({
+    platform: platformCloudflare({
+        mode: "detached",
+    }),
+});
+```

--- a/packages/io/src/AbstractPlatform.ts
+++ b/packages/io/src/AbstractPlatform.ts
@@ -70,7 +70,7 @@ export abstract class AbstractPlatform<
 
     public abstract getSerializedState(webSocket: AbstractWebSocket): WebSocketSerializedState | null;
 
-    public abstract getSessionId(webSocket: AbstractWebSocket): string | null;
+    public abstract getSessionId(webSocket: InferWebSocketSource<TWebSocket>): string | null;
 
     public abstract getWebSockets(): readonly InferWebSocketSource<TWebSocket>[];
 

--- a/packages/platform-cloudflare/src/CloudflarePlatform.ts
+++ b/packages/platform-cloudflare/src/CloudflarePlatform.ts
@@ -74,8 +74,8 @@ export class CloudflarePlatform<TEnv extends Record<string, any> = {}> extends A
         return deserialized?.state ?? null;
     }
 
-    public getSessionId(webSocket: CloudflareWebSocket): string | null {
-        const deserialized = webSocket.webSocket.deserializeAttachment() ?? {};
+    public getSessionId(webSocket: WebSocket): string | null {
+        const deserialized = webSocket.deserializeAttachment() ?? {};
         const sessionId = deserialized.sessionId;
 
         if (typeof sessionId !== "string") {

--- a/packages/platform-cloudflare/src/constants.ts
+++ b/packages/platform-cloudflare/src/constants.ts
@@ -1,3 +1,3 @@
 import type { WebSocketRegistrationMode } from "@pluv/io";
 
-export const DEFAULT_REGISTRATION_MODE: WebSocketRegistrationMode = "attached";
+export const DEFAULT_REGISTRATION_MODE: WebSocketRegistrationMode = "detached";

--- a/packages/platform-cloudflare/src/platformCloudflare.ts
+++ b/packages/platform-cloudflare/src/platformCloudflare.ts
@@ -1,5 +1,6 @@
+import type { CloudflarePlatformConfig } from "./CloudflarePlatform";
 import { CloudflarePlatform } from "./CloudflarePlatform";
 
-export const platformCloudflare = <TEnv extends Record<string, any> = {}>(): CloudflarePlatform<TEnv> => {
-    return new CloudflarePlatform<TEnv>();
+export const platformCloudflare = <TEnv extends Record<string, any> = {}>(config: CloudflarePlatformConfig<TEnv> = {}): CloudflarePlatform<TEnv> => {
+    return new CloudflarePlatform<TEnv>(config);
 };

--- a/packages/platform-node/src/NodePlatform.ts
+++ b/packages/platform-node/src/NodePlatform.ts
@@ -46,7 +46,7 @@ export class NodePlatform extends AbstractPlatform<NodeWebSocket> {
         return null;
     }
 
-    public getSessionId(webSocket: NodeWebSocket): string | null {
+    public getSessionId(webSocket: WebSocket): string | null {
         return null;
     }
 

--- a/packages/platform-node/src/NodePlatform.ts
+++ b/packages/platform-node/src/NodePlatform.ts
@@ -12,7 +12,7 @@ import { TextDecoder } from "node:util";
 import type { WebSocket } from "ws";
 import { NodeWebSocket } from "./NodeWebSocket";
 
-export type NodePlatformOptions = { mode?: WebSocketRegistrationMode } & (
+export type NodePlatformConfig = { mode?: WebSocketRegistrationMode } & (
     | { persistance?: undefined; pubSub?: undefined }
     | { persistance: AbstractPersistance; pubSub: AbstractPubSub }
 );
@@ -20,8 +20,8 @@ export type NodePlatformOptions = { mode?: WebSocketRegistrationMode } & (
 export class NodePlatform extends AbstractPlatform<NodeWebSocket> {
     readonly _registrationMode: WebSocketRegistrationMode;
 
-    constructor(options: NodePlatformOptions = {}) {
-        const { mode = "attached", persistance, pubSub } = options;
+    constructor(config: NodePlatformConfig = {}) {
+        const { mode = "attached", persistance, pubSub } = config;
 
         super(persistance && pubSub ? { persistance, pubSub } : {});
 
@@ -60,7 +60,7 @@ export class NodePlatform extends AbstractPlatform<NodeWebSocket> {
             persistance: this.persistance,
             pubSub: this.pubSub,
             ...config,
-        } as NodePlatformOptions)._initialize() as this;
+        } as NodePlatformConfig)._initialize() as this;
     }
 
     public parseData(data: string | ArrayBuffer): Record<string, any> {

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -1,5 +1,5 @@
 export type { AuthorizeFunction, AuthorizeFunctionContext, CreatePluvHandlerConfig } from "./createPluvHandler";
 export { createPluvHandler } from "./createPluvHandler";
 export type { WebSocket } from "ws";
-export type { NodePlatformOptions } from "./NodePlatform";
+export type { NodePlatformConfig } from "./NodePlatform";
 export { platformNode } from "./platformNode";

--- a/packages/platform-node/src/platformNode.ts
+++ b/packages/platform-node/src/platformNode.ts
@@ -1,6 +1,6 @@
-import type { NodePlatformOptions } from "./NodePlatform";
+import type { NodePlatformConfig } from "./NodePlatform";
 import { NodePlatform } from "./NodePlatform";
 
-export const platformNode = (options: NodePlatformOptions = {}): NodePlatform => {
-    return new NodePlatform(options);
+export const platformNode = (config: NodePlatformConfig = {}): NodePlatform => {
+    return new NodePlatform(config);
 };


### PR DESCRIPTION
Closes #670

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

* Support Cloudflare Worker WebSocket Hibernation API.
* Default `@pluv/platform-cloudflare` to use detached mode (i.e. use websocket hibernation by default).