### PR TITLE
feat(io): update event listeners to be configured on the server

### DIFF
--- a/.changeset/chatty-grapes-hug.md
+++ b/.changeset/chatty-grapes-hug.md
@@ -1,0 +1,62 @@
+---
+"@pluv/io": minor
+---
+
+**BREAKING**
+
+Moved `getInitialStorage`, `onRoomDeleted` and `onStorageUpdated` from `createIO` to `PluvIO.server`.
+
+```ts
+import { createIO } from "@pluv/io";
+
+// Before
+const io = createIO({
+    // ...
+    getInitialStorage: (event) => {
+        // ...
+    },
+    onRoomDeleted: (event) => {
+        // ...
+    },
+    onStorageUpdated: (event) => {
+        // ...
+    },
+    // ...
+});
+
+const ioServer = io.server({
+    // ...
+});
+
+// After
+const io = createIO({
+    // ...
+});
+
+const ioServer = io.server({
+    // ...
+    getInitialStorage: (event) => {
+        // ...
+    },
+    onRoomDeleted: (event) => {
+        // ...
+    },
+    onStorageUpdated: (event) => {
+        // ...
+    },
+    // ...
+});
+```
+
+Added a new listener `onRoomMessage` to `PluvIO.server` to listen to events that are sent within a room.
+
+```ts
+const ioServer = io.server({
+    // ...
+    onRoomMessage: (event) => {
+        console.log(event.message);
+        console.log(event.user);
+    },
+    // ...
+});
+```

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -87,20 +87,19 @@ export class IORoom<
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
 > implements IOLike<TAuthorize, TEvents>
 {
+    public readonly id: string;
+    public readonly _authorize: TAuthorize | null = null;
+
+    private _doc: AbstractCrdtDoc<any>;
+    private _uninitialize: (() => Promise<void>) | null = null;
+
     private readonly _context: TContext & InferRoomContextType<TPlatform>;
     private readonly _debug: boolean;
     private readonly _docFactory: AbstractCrdtDocFactory<any>;
+    private readonly _listeners: IORoomListeners<TPlatform, TAuthorize, TContext, TEvents>;
     private readonly _platform: TPlatform;
-
-    private _doc: AbstractCrdtDoc<any>;
-    private _listeners: IORoomListeners<TPlatform, TAuthorize, TContext, TEvents>;
-    private _sessions = new Map<string, AbstractWebSocket>();
-    private _uninitialize: (() => Promise<void>) | null = null;
-
-    readonly _authorize: TAuthorize | null = null;
-    readonly _router: PluvRouter<TPlatform, TAuthorize, TContext, TEvents>;
-
-    readonly id: string;
+    private readonly _router: PluvRouter<TPlatform, TAuthorize, TContext, TEvents>;
+    private readonly _sessions = new Map<string, AbstractWebSocket>();
 
     public get _events() {
         return this._router._events;

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -613,6 +613,7 @@ export class IORoom<
             encodedState: this._doc.getEncodedState(),
             message: { data, type } as InferEventMessage<InferEventsOutput<TEvents>, keyof InferEventsOutput<TEvents>>,
             room: this.id,
+            user: message.user,
         });
 
         await Promise.resolve(pluvWs.sendMessage(message));

--- a/packages/io/src/PluvIO.ts
+++ b/packages/io/src/PluvIO.ts
@@ -1,14 +1,6 @@
 import type { AbstractCrdtDocFactory } from "@pluv/crdt";
 import { noop } from "@pluv/crdt";
-import type {
-    BaseIOAuthorize,
-    IOAuthorize,
-    IOLike,
-    InferIOAuthorize,
-    InferIOAuthorizeUser,
-    JsonObject,
-    Maybe,
-} from "@pluv/types";
+import type { BaseIOAuthorize, IOAuthorize, InferIOAuthorizeUser, JsonObject } from "@pluv/types";
 import type { AbstractPlatform, InferPlatformContextType, WebSocketRegistrationMode } from "./AbstractPlatform";
 import { PluvProcedure } from "./PluvProcedure";
 import type { MergedRouter, PluvRouterEventConfig } from "./PluvRouter";
@@ -16,7 +8,6 @@ import { PluvRouter } from "./PluvRouter";
 import { PluvServer } from "./PluvServer";
 import type { JWTEncodeParams } from "./authorize";
 import { authorize } from "./authorize";
-import { PING_TIMEOUT_MS } from "./constants";
 import type { GetInitialStorageFn, PluvIOListeners } from "./types";
 import { __PLUV_VERSION } from "./version";
 
@@ -24,167 +15,35 @@ export type PluvIOConfig<
     TPlatform extends AbstractPlatform<any>,
     TAuthorize extends IOAuthorize<any, any, InferPlatformContextType<TPlatform>>,
     TContext extends JsonObject,
-> = Partial<PluvIOListeners<TPlatform>> & {
+> = {
     authorize?: TAuthorize;
     context?: TContext;
     crdt?: { doc: (value: any) => AbstractCrdtDocFactory<any> };
     debug?: boolean;
-    getInitialStorage?: GetInitialStorageFn<TPlatform>;
     platform: TPlatform;
 };
 
-export interface ServerConfig<
+export type ServerConfig<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
     TAuthorize extends IOAuthorize<any, any, InferPlatformContextType<TPlatform>> = BaseIOAuthorize,
     TContext extends JsonObject = {},
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
-> {
+> = Partial<PluvIOListeners<TPlatform, TAuthorize, TContext, TEvents>> & {
+    getInitialStorage?: GetInitialStorageFn<TPlatform>;
     router?: PluvRouter<TPlatform, TAuthorize, TContext, TEvents>;
-}
+};
 
 export class PluvIO<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
     TAuthorize extends IOAuthorize<any, any, InferPlatformContextType<TPlatform>> = BaseIOAuthorize,
     TContext extends JsonObject = {},
-> implements IOLike<TAuthorize, {}>
-{
-    private _router: PluvRouter<TPlatform, TAuthorize, TContext, {}> = new PluvRouter({
-        $GET_OTHERS: this.procedure.sync((data, { room, session, sessions }) => {
-            const currentTime = new Date().getTime();
-
-            const others = sessions
-                .filter((wsSession) => {
-                    if (wsSession.id === session?.id) return false;
-                    if (wsSession.quit) return false;
-                    if (currentTime - wsSession.timers.ping > PING_TIMEOUT_MS) return false;
-
-                    return true;
-                })
-                .reduce<{
-                    [connectionId: string]: {
-                        connectionId: string;
-                        room: string | null;
-                        user: JsonObject;
-                    };
-                }>(
-                    (acc, { id, presence, user }) => ({
-                        ...acc,
-                        [id]: {
-                            connectionId: id,
-                            presence,
-                            room,
-                            user,
-                        },
-                    }),
-                    {},
-                );
-
-            return { $OTHERS_RECEIVED: { others } };
-        }),
-        $INITIALIZE_SESSION: this.procedure
-            .broadcast((data, { session }) => {
-                const presence = (data as any)?.presence;
-
-                if (!session) return {};
-
-                session.presence = presence;
-
-                return {
-                    $USER_JOINED: {
-                        connectionId: session.id,
-                        user: session.user,
-                        presence,
-                    },
-                };
-            })
-            .self(async (data, { context, doc, room }) => {
-                const oldState = await this._platform.persistance.getStorageState(room);
-                const update = (data as any)?.update as Maybe<string>;
-
-                const updates: readonly Maybe<string>[] = [
-                    oldState
-                        ? null
-                        : await this._getInitialStorage?.({
-                              ...context,
-                              room,
-                          }),
-                    update,
-                ];
-
-                if (updates.some((_update) => !!_update)) {
-                    const encodedState = doc.batchApplyEncodedState(updates).getEncodedState();
-
-                    await this._platform.persistance.setStorageState(room, encodedState);
-
-                    this._listeners.onStorageUpdated({ ...context, encodedState, room });
-                }
-
-                const state = (await this._platform.persistance.getStorageState(room)) ?? doc.getEncodedState();
-
-                return { $STORAGE_RECEIVED: { state } };
-            }),
-        $PING: this.procedure.self((data, { session }) => {
-            if (!session) return {};
-
-            const currentTime = new Date().getTime();
-            const prevState = session.webSocket.state;
-
-            session.webSocket.state = {
-                ...prevState,
-                timers: {
-                    ...prevState.timers,
-                    ping: currentTime,
-                },
-            };
-
-            return { $PONG: {} };
-        }),
-        $UPDATE_PRESENCE: this.procedure.broadcast((data, { session }) => {
-            const presence = (data as any)?.presence;
-
-            if (!session) return {};
-
-            const updated = Object.assign(Object.create(null), session.presence, presence);
-
-            session.webSocket.presence = updated;
-
-            return { $PRESENCE_UPDATED: { presence: updated } };
-        }),
-        $UPDATE_STORAGE: this.procedure.broadcast((data, { context, doc, room }) => {
-            const origin = (data as any)?.origin as Maybe<string>;
-            const update: string | null = (data as any)?.update ?? null;
-
-            if (origin === "$INITIALIZED" && Object.keys(doc.toJson()).length) {
-                return {};
-            }
-
-            const updated = update === null ? doc : doc.applyEncodedState({ update });
-            const encodedState = updated.getEncodedState();
-
-            this._platform.persistance.setStorageState(room, encodedState).then(() => {
-                this._listeners.onStorageUpdated({
-                    ...context,
-                    encodedState,
-                    room,
-                });
-            });
-
-            return { $STORAGE_UPDATED: { state: encodedState } };
-        }),
-    });
-
+> {
     readonly _authorize: TAuthorize | null = null;
     readonly _context: TContext = {} as TContext;
     readonly _crdt: { doc: (value: any) => AbstractCrdtDocFactory<any> };
     readonly _debug: boolean;
-    readonly _getInitialStorage: GetInitialStorageFn<TPlatform> | null = null;
-    readonly _listeners: PluvIOListeners<TPlatform>;
     readonly _platform: TPlatform;
     readonly _version: string = __PLUV_VERSION as any;
-
-    public get _events() {
-        return this._router._events;
-    }
 
     public get _registrationMode(): WebSocketRegistrationMode {
         return this._platform._registrationMode;
@@ -195,16 +54,7 @@ export class PluvIO<
     }
 
     constructor(options: PluvIOConfig<TPlatform, TAuthorize, TContext>) {
-        const {
-            authorize,
-            context,
-            crdt = noop,
-            debug = false,
-            getInitialStorage,
-            onRoomDeleted,
-            onStorageUpdated,
-            platform,
-        } = options;
+        const { authorize, context, crdt = noop, debug = false, platform } = options;
 
         this._crdt = crdt;
         this._debug = debug;
@@ -212,17 +62,9 @@ export class PluvIO<
 
         if (authorize) this._authorize = authorize;
         if (context) this._context = context;
-        if (getInitialStorage) this._getInitialStorage = getInitialStorage;
-
-        this._listeners = {
-            onRoomDeleted: (event) => onRoomDeleted?.(event),
-            onStorageUpdated: (event) => onStorageUpdated?.(event),
-        };
     }
 
-    public async createToken(
-        params: JWTEncodeParams<InferIOAuthorizeUser<InferIOAuthorize<this>>, TPlatform>,
-    ): Promise<string> {
+    public async createToken(params: JWTEncodeParams<InferIOAuthorizeUser<TAuthorize>, TPlatform>): Promise<string> {
         if (!this._authorize) throw new Error("IO does not specify authorize during initialization.");
 
         const ioAuthorize =
@@ -251,21 +93,13 @@ export class PluvIO<
     public server<TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>>(
         config: ServerConfig<TPlatform, TAuthorize, TContext, TEvents> = {},
     ): PluvServer<TPlatform, TAuthorize, TContext, TEvents> {
-        const router = (config.router ? this.mergeRouters(this._router, config.router) : this._router) as PluvRouter<
-            TPlatform,
-            TAuthorize,
-            TContext,
-            TEvents
-        >;
-
         return new PluvServer<TPlatform, TAuthorize, TContext, TEvents>({
-            ...this._listeners,
+            ...config,
             authorize: this._authorize ?? undefined,
             context: this._context,
             crdt: this._crdt,
             debug: this._debug,
             platform: this._platform,
-            router,
         });
     }
 }

--- a/packages/io/src/PluvIO.ts
+++ b/packages/io/src/PluvIO.ts
@@ -38,12 +38,13 @@ export class PluvIO<
     TAuthorize extends IOAuthorize<any, any, InferPlatformContextType<TPlatform>> = BaseIOAuthorize,
     TContext extends JsonObject = {},
 > {
-    readonly _authorize: TAuthorize | null = null;
-    readonly _context: TContext = {} as TContext;
-    readonly _crdt: { doc: (value: any) => AbstractCrdtDocFactory<any> };
-    readonly _debug: boolean;
-    readonly _platform: TPlatform;
-    readonly _version: string = __PLUV_VERSION as any;
+    public readonly version: string = __PLUV_VERSION as any;
+    public readonly _authorize: TAuthorize | null = null;
+
+    private readonly _context: TContext = {} as TContext;
+    private readonly _crdt: { doc: (value: any) => AbstractCrdtDocFactory<any> };
+    private readonly _debug: boolean;
+    private readonly _platform: TPlatform;
 
     public get _registrationMode(): WebSocketRegistrationMode {
         return this._platform._registrationMode;

--- a/packages/io/src/PluvRouter.ts
+++ b/packages/io/src/PluvRouter.ts
@@ -6,9 +6,7 @@ export type PluvRouterEventConfig<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
     TAuthorize extends IOAuthorize<any, any, InferRoomContextType<TPlatform>> = BaseIOAuthorize,
     TContext extends JsonObject = {},
-> = {
-    [P: string]: Pick<PluvProcedure<TPlatform, TAuthorize, TContext, any, any>, "config">;
-};
+> = { [P: string]: Pick<PluvProcedure<TPlatform, TAuthorize, TContext, any, any>, "config"> };
 
 export type MergedRouter<
     TRouters extends PluvRouter<TPlatform, TAuthorize, TContext, any>[] = [],

--- a/packages/io/src/PluvServer.ts
+++ b/packages/io/src/PluvServer.ts
@@ -60,18 +60,10 @@ export class PluvServer<
 {
     public _listeners: PluvIOListeners<TPlatform, TAuthorize, TContext, TEvents>;
 
-    readonly _authorize: TAuthorize | null = null;
-    readonly _context: TContext = {} as TContext;
-    readonly _crdt: { doc: (value: any) => AbstractCrdtDocFactory<any> };
-    readonly _debug: boolean;
-    readonly _getInitialStorage: GetInitialStorageFn<TPlatform> | null = null;
-    readonly _platform: TPlatform;
-    readonly _router: PluvRouter<TPlatform, TAuthorize, TContext, TEvents>;
-    readonly _version: string = __PLUV_VERSION as any;
+    public readonly version: string = __PLUV_VERSION as any;
+    public readonly _authorize: TAuthorize | null = null;
 
-    private _rooms = new Map<string, IORoom<TPlatform, TAuthorize, TContext, TEvents>>();
-
-    private _baseRouter: PluvRouter<TPlatform, TAuthorize, TContext, {}> = new PluvRouter({
+    private readonly _baseRouter: PluvRouter<TPlatform, TAuthorize, TContext, {}> = new PluvRouter({
         $GET_OTHERS: this._procedure.sync((data, { room, session, sessions }) => {
             const currentTime = new Date().getTime();
 
@@ -195,6 +187,13 @@ export class PluvServer<
             return { $STORAGE_UPDATED: { state: encodedState } };
         }),
     });
+    private readonly _context: TContext = {} as TContext;
+    private readonly _crdt: { doc: (value: any) => AbstractCrdtDocFactory<any> };
+    private readonly _debug: boolean;
+    private readonly _getInitialStorage: GetInitialStorageFn<TPlatform> | null = null;
+    private readonly _platform: TPlatform;
+    private readonly _rooms = new Map<string, IORoom<TPlatform, TAuthorize, TContext, TEvents>>();
+    private readonly _router: PluvRouter<TPlatform, TAuthorize, TContext, TEvents>;
 
     public get _events() {
         return this._router._events;

--- a/packages/io/src/PluvServer.ts
+++ b/packages/io/src/PluvServer.ts
@@ -8,6 +8,7 @@ import type {
     InferIOAuthorize,
     InferIOAuthorizeUser,
     JsonObject,
+    Maybe,
 } from "@pluv/types";
 import colors from "kleur";
 import type {
@@ -17,11 +18,13 @@ import type {
     WebSocketRegistrationMode,
 } from "./AbstractPlatform";
 import { IORoom } from "./IORoom";
+import { PluvProcedure } from "./PluvProcedure";
 import type { PluvRouterEventConfig } from "./PluvRouter";
 import { PluvRouter } from "./PluvRouter";
 import type { JWTEncodeParams } from "./authorize";
 import { authorize } from "./authorize";
-import type { IORoomListenerEvent, PluvIOListeners } from "./types";
+import { PING_TIMEOUT_MS } from "./constants";
+import type { GetInitialStorageFn, PluvIOListeners } from "./types";
 import { __PLUV_VERSION } from "./version";
 
 export type InferIORoom<TServer extends PluvServer<any, any, any, any>> =
@@ -34,11 +37,12 @@ export type PluvServerConfig<
     TAuthorize extends IOAuthorize<any, any, InferPlatformContextType<TPlatform>> = BaseIOAuthorize,
     TContext extends JsonObject = {},
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
-> = Partial<PluvIOListeners<TPlatform>> & {
+> = Partial<PluvIOListeners<TPlatform, TAuthorize, TContext, TEvents>> & {
     authorize?: TAuthorize;
     context?: TContext;
     crdt?: { doc: (value: any) => AbstractCrdtDocFactory<any> };
     debug?: boolean;
+    getInitialStorage?: GetInitialStorageFn<TPlatform>;
     platform: TPlatform;
     router?: PluvRouter<TPlatform, TAuthorize, TContext, TEvents>;
 };
@@ -54,16 +58,143 @@ export class PluvServer<
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
 > implements IORouterLike<TEvents>
 {
-    private _rooms = new Map<string, IORoom<TPlatform, TAuthorize, TContext, TEvents>>();
+    public _listeners: PluvIOListeners<TPlatform, TAuthorize, TContext, TEvents>;
 
     readonly _authorize: TAuthorize | null = null;
     readonly _context: TContext = {} as TContext;
     readonly _crdt: { doc: (value: any) => AbstractCrdtDocFactory<any> };
     readonly _debug: boolean;
-    readonly _listeners: PluvIOListeners<TPlatform>;
+    readonly _getInitialStorage: GetInitialStorageFn<TPlatform> | null = null;
     readonly _platform: TPlatform;
     readonly _router: PluvRouter<TPlatform, TAuthorize, TContext, TEvents>;
     readonly _version: string = __PLUV_VERSION as any;
+
+    private _rooms = new Map<string, IORoom<TPlatform, TAuthorize, TContext, TEvents>>();
+
+    private _baseRouter: PluvRouter<TPlatform, TAuthorize, TContext, {}> = new PluvRouter({
+        $GET_OTHERS: this._procedure.sync((data, { room, session, sessions }) => {
+            const currentTime = new Date().getTime();
+
+            const others = sessions
+                .filter((wsSession) => {
+                    if (wsSession.id === session?.id) return false;
+                    if (wsSession.quit) return false;
+                    if (currentTime - wsSession.timers.ping > PING_TIMEOUT_MS) return false;
+
+                    return true;
+                })
+                .reduce<{
+                    [connectionId: string]: {
+                        connectionId: string;
+                        room: string | null;
+                        user: JsonObject;
+                    };
+                }>(
+                    (acc, { id, presence, user }) => ({
+                        ...acc,
+                        [id]: {
+                            connectionId: id,
+                            presence,
+                            room,
+                            user,
+                        },
+                    }),
+                    {},
+                );
+
+            return { $OTHERS_RECEIVED: { others } };
+        }),
+        $INITIALIZE_SESSION: this._procedure
+            .broadcast((data, { session }) => {
+                const presence = (data as any)?.presence;
+
+                if (!session) return {};
+
+                session.presence = presence;
+
+                return {
+                    $USER_JOINED: {
+                        connectionId: session.id,
+                        user: session.user,
+                        presence,
+                    },
+                };
+            })
+            .self(async (data, { context, doc, room }) => {
+                const oldState = await this._platform.persistance.getStorageState(room);
+                const update = (data as any)?.update as Maybe<string>;
+
+                const updates: readonly Maybe<string>[] = [
+                    oldState
+                        ? null
+                        : await this._getInitialStorage?.({
+                              ...context,
+                              room,
+                          }),
+                    update,
+                ];
+
+                if (updates.some((_update) => !!_update)) {
+                    const encodedState = doc.batchApplyEncodedState(updates).getEncodedState();
+
+                    await this._platform.persistance.setStorageState(room, encodedState);
+
+                    this._listeners.onStorageUpdated({ context, encodedState, room });
+                }
+
+                const state = (await this._platform.persistance.getStorageState(room)) ?? doc.getEncodedState();
+
+                return { $STORAGE_RECEIVED: { state } };
+            }),
+        $PING: this._procedure.self((data, { session }) => {
+            if (!session) return {};
+
+            const currentTime = new Date().getTime();
+            const prevState = session.webSocket.state;
+
+            session.webSocket.state = {
+                ...prevState,
+                timers: {
+                    ...prevState.timers,
+                    ping: currentTime,
+                },
+            };
+
+            return { $PONG: {} };
+        }),
+        $UPDATE_PRESENCE: this._procedure.broadcast((data, { session }) => {
+            const presence = (data as any)?.presence;
+
+            if (!session) return {};
+
+            const updated = Object.assign(Object.create(null), session.presence, presence);
+
+            session.webSocket.presence = updated;
+
+            return { $PRESENCE_UPDATED: { presence: updated } };
+        }),
+        $UPDATE_STORAGE: this._procedure.broadcast((data, { context, doc, room }) => {
+            const origin = (data as any)?.origin as Maybe<string>;
+            const update: string | null = (data as any)?.update ?? null;
+
+            if (origin === "$INITIALIZED" && Object.keys(doc.toJson()).length) {
+                return {};
+            }
+
+            const updated = update === null ? doc : doc.applyEncodedState({ update });
+            const encodedState = updated.getEncodedState();
+
+            this._platform.persistance.setStorageState(room, encodedState).then(() => {
+                this._listeners.onStorageUpdated({
+                    context,
+                    encodedState,
+                    room,
+                });
+            });
+
+            return { $STORAGE_UPDATED: { state: encodedState } };
+        }),
+    });
 
     public get _events() {
         return this._router._events;
@@ -73,13 +204,19 @@ export class PluvServer<
         return this._platform._registrationMode;
     }
 
+    private get _procedure(): PluvProcedure<TPlatform, TAuthorize, TContext, {}, {}> {
+        return new PluvProcedure();
+    }
+
     constructor(options: PluvServerConfig<TPlatform, TAuthorize, TContext, TEvents>) {
         const {
             authorize,
             context,
             crdt = noop,
             debug = false,
+            getInitialStorage,
             onRoomDeleted,
+            onRoomMessage,
             onStorageUpdated,
             platform,
             router = new PluvRouter<TPlatform, TAuthorize, TContext, TEvents>({} as TEvents),
@@ -88,13 +225,20 @@ export class PluvServer<
         this._crdt = crdt;
         this._debug = debug;
         this._platform = platform;
-        this._router = router ?? null;
+        this._router = (router ? this._baseRouter : PluvRouter.merge(this._baseRouter, router)) as PluvRouter<
+            TPlatform,
+            TAuthorize,
+            TContext,
+            TEvents
+        >;
 
         if (authorize) this._authorize = authorize;
         if (context) this._context = context;
+        if (getInitialStorage) this._getInitialStorage = getInitialStorage;
 
         this._listeners = {
             onRoomDeleted: (event) => onRoomDeleted?.(event),
+            onRoomMessage: (event) => onRoomMessage?.(event),
             onStorageUpdated: (event) => onStorageUpdated?.(event),
         };
     }
@@ -144,18 +288,11 @@ export class PluvServer<
             context: roomContext,
             crdt: this._crdt,
             debug: debug ?? this._debug,
-            onDestroy: async ({ encodedState, room }) => {
+            onDestroy: async (event) => {
                 this._logDebug(`${colors.blue("Deleting empty room:")} ${room}`);
-
-                const roomContext = {
-                    room,
-                    encodedState,
-                    ...platformRoomContext,
-                } as IORoomListenerEvent<TPlatform> & InferRoomContextType<TPlatform>;
-
                 this._rooms.delete(room);
 
-                await Promise.resolve(this._listeners.onRoomDeleted(roomContext));
+                await Promise.resolve(this._listeners.onRoomDeleted(event));
                 await this._platform.persistance.deleteStorageState(room);
 
                 if (this._debug) {
@@ -164,6 +301,9 @@ export class PluvServer<
                     this._logDebug(`${colors.blue("Deleted room:")} ${room}`);
                     this._logDebug(`${colors.blue("Rooms available:")} ${rooms.join(", ")}`);
                 }
+            },
+            onMessage: async (event) => {
+                await Promise.resolve(this._listeners.onRoomMessage(event));
             },
             platform,
             router: this._router,

--- a/packages/io/src/createIO.ts
+++ b/packages/io/src/createIO.ts
@@ -2,19 +2,18 @@ import type { AbstractCrdtDocFactory } from "@pluv/crdt";
 import type { BaseUser, IOAuthorize, JsonObject } from "@pluv/types";
 import type { AbstractPlatform, InferPlatformContextType } from "./AbstractPlatform";
 import { PluvIO } from "./PluvIO";
-import type { GetInitialStorageFn, PluvIOListeners } from "./types";
+import type { GetInitialStorageFn } from "./types";
 
 export type CreateIOParams<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
     TContext extends JsonObject = {},
     TAuthorizeUser extends BaseUser = BaseUser,
     TAuthorizeRequired extends boolean = false,
-> = Partial<PluvIOListeners<TPlatform>> & {
+> = {
     authorize?: IOAuthorize<TAuthorizeUser, TAuthorizeRequired, InferPlatformContextType<TPlatform>>;
     context?: TContext;
     crdt?: { doc: (value: any) => AbstractCrdtDocFactory<any> };
     debug?: boolean;
-    getInitialStorage?: GetInitialStorageFn<TPlatform>;
     platform: TPlatform;
 };
 
@@ -30,7 +29,7 @@ export const createIO = <
     IOAuthorize<TAuthorizeUser, TAuthorizeRequired, InferPlatformContextType<TPlatform>>,
     TContext
 > => {
-    const { authorize, context, crdt, debug, getInitialStorage, onRoomDeleted, onStorageUpdated, platform } = params;
+    const { authorize, context, crdt, debug, platform } = params;
 
     return new PluvIO<
         TPlatform,
@@ -41,9 +40,6 @@ export const createIO = <
         context,
         crdt,
         debug,
-        getInitialStorage,
-        onRoomDeleted,
-        onStorageUpdated,
         platform,
     });
 };

--- a/packages/io/src/types.ts
+++ b/packages/io/src/types.ts
@@ -135,6 +135,7 @@ export type IORoomMessageEvent<
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>,
 > = IORoomListenerEvent<TPlatform, TAuthorize, TContext, TEvents> & {
     message: InferEventMessage<InferEventsOutput<TEvents>, keyof InferEventsOutput<TEvents>>;
+    user?: InferIOAuthorizeUser<TAuthorize>;
 };
 
 export type WebSocketType<TPlatform extends AbstractPlatform> =

--- a/packages/io/src/types.ts
+++ b/packages/io/src/types.ts
@@ -3,8 +3,12 @@ import type {
     BaseIOAuthorize,
     EventRecord,
     IOAuthorize,
+    IORouterLike,
     Id,
+    InferEventMessage,
+    InferEventsOutput,
     InferIOAuthorizeUser,
+    InferIOOutput,
     JsonObject,
     Maybe,
     MaybePromise,
@@ -16,6 +20,7 @@ import type {
     InferRoomContextType,
 } from "./AbstractPlatform";
 import type { AbstractWebSocket } from "./AbstractWebSocket";
+import type { PluvRouterEventConfig } from "./PluvRouter";
 
 declare global {
     var console: {
@@ -101,15 +106,36 @@ export type GetInitialStorageFn<TPlatform extends AbstractPlatform> = (
     event: GetInitialStorageEvent<TPlatform>,
 ) => MaybePromise<Maybe<string>>;
 
-export interface PluvIOListeners<TPlatform extends AbstractPlatform> {
-    onRoomDeleted: (event: IORoomListenerEvent<TPlatform>) => void;
-    onStorageUpdated: (event: IORoomListenerEvent<TPlatform>) => void;
+export interface PluvIOListeners<
+    TPlatform extends AbstractPlatform<any>,
+    TAuthorize extends IOAuthorize<any, any, InferRoomContextType<TPlatform>>,
+    TContext extends JsonObject,
+    TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>,
+> {
+    onRoomDeleted: (event: IORoomListenerEvent<TPlatform, TAuthorize, TContext, TEvents>) => void;
+    onRoomMessage: (event: IORoomMessageEvent<TPlatform, TAuthorize, TContext, TEvents>) => void;
+    onStorageUpdated: (event: IORoomListenerEvent<TPlatform, TAuthorize, TContext, TEvents>) => void;
 }
 
-export type IORoomListenerEvent<TPlatform extends AbstractPlatform> = {
-    room: string;
+export type IORoomListenerEvent<
+    TPlatform extends AbstractPlatform<any>,
+    TAuthorize extends IOAuthorize<any, any, InferRoomContextType<TPlatform>>,
+    TContext extends JsonObject,
+    TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>,
+> = {
+    context: TContext & InferRoomContextType<TPlatform>;
     encodedState: string | null;
-} & InferRoomContextType<TPlatform>;
+    room: string;
+};
+
+export type IORoomMessageEvent<
+    TPlatform extends AbstractPlatform<any>,
+    TAuthorize extends IOAuthorize<any, any, InferRoomContextType<TPlatform>>,
+    TContext extends JsonObject,
+    TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>,
+> = IORoomListenerEvent<TPlatform, TAuthorize, TContext, TEvents> & {
+    message: InferEventMessage<InferEventsOutput<TEvents>, keyof InferEventsOutput<TEvents>>;
+};
 
 export type WebSocketType<TPlatform extends AbstractPlatform> =
     | InferPlatformWebSocketType<TPlatform>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -32,6 +32,8 @@ export type {
     IOLike,
     IORouterLike,
     InferEventMessage,
+    InferEventsInput,
+    InferEventsOutput,
     InferIOAuthorize,
     InferIOAuthorizeRequired,
     InferIOAuthorizeUser,

--- a/packages/types/src/pluv.ts
+++ b/packages/types/src/pluv.ts
@@ -152,26 +152,26 @@ export interface IOLike<
     _authorize: TAuthorize | null;
 }
 
+export type InferEventsInput<TEvents extends Record<string, ProcedureLike<any, any>>> = {
+    [P in keyof TEvents]: TEvents[P] extends ProcedureLike<infer IInput, any> ? IInput : never;
+};
+
+export type InferEventsOutput<TEvents extends Record<string, ProcedureLike<any, any>>> = UnionToIntersection<
+    {
+        [P in keyof TEvents]: TEvents[P] extends ProcedureLike<any, infer IOutput> ? IOutput : never;
+    }[keyof TEvents]
+>;
+
 export type InferIOInput<TRouter extends IORouterLike<any>> =
-    TRouter extends IORouterLike<infer IEvents>
-        ? { [P in keyof IEvents]: IEvents[P] extends ProcedureLike<infer IInput, any> ? IInput : never }
-        : never;
+    TRouter extends IORouterLike<infer IEvents> ? InferEventsInput<IEvents> : never;
 
 export type InferIOOutput<TRouter extends IORouterLike<any>> =
-    TRouter extends IORouterLike<infer IEvents>
-        ? UnionToIntersection<
-              {
-                  [P in keyof IEvents]: IEvents[P] extends ProcedureLike<any, infer IOutput> ? IOutput : never;
-              }[keyof IEvents]
-          >
-        : never;
+    TRouter extends IORouterLike<infer IEvents> ? InferEventsOutput<IEvents> : never;
 
-export type InferEventMessage<
-    TEvents extends EventRecord<string, any> = EventRecord<string, any>,
-    TEvent extends keyof TEvents = keyof TEvents,
-> = {
-    [P in TEvent]: P extends string ? Id<EventMessage<P, TEvents[P]>> : never;
-}[TEvent];
+export type InferEventMessage<TEvents = EventRecord<string, any>, TEvent extends keyof TEvents = keyof TEvents> =
+    TEvents extends EventRecord<string, any>
+        ? { [P in TEvent]: P extends string ? Id<EventMessage<P, TEvents[P]>> : never }[TEvent]
+        : never;
 
 export type IOEventMessage<
     TIO extends IOLike<any>,


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Updated `onRoomDeleted` and `onStorageUpdated` to be configured on `io.server` instead of on `createIO`.