### PR TITLE
fix(client): clear users on ws close

### DIFF
--- a/.changeset/beige-seas-beg.md
+++ b/.changeset/beige-seas-beg.md
@@ -1,0 +1,5 @@
+---
+"@pluv/client": patch
+---
+
+Fixed "others" state in the PluvClient not getting cleared when the user's websocket connection is closed, creating "ghost users" during some reconnects.

--- a/packages/client/src/OtherNotifier.ts
+++ b/packages/client/src/OtherNotifier.ts
@@ -8,6 +8,15 @@ export type OtherNotifierSubscriptionCallback<TIO extends IOLike> = (value: Id<U
 export class OtherNotifier<TIO extends IOLike> {
     public subjects = new Map<string, Subject<Id<UserInfo<TIO>> | null>>();
 
+    public clear(): void {
+        const connectionIds = Array.from(this.subjects.keys());
+
+        connectionIds.forEach((connectionId) => {
+            this.subject(connectionId).next(null);
+            this.subjects.delete(connectionId);
+        });
+    }
+
     public subject<TEvent extends string>(name: TEvent): Subject<Id<UserInfo<TIO>> | null> {
         const subject = this.subjects.get(name);
 

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -534,7 +534,12 @@ export class PluvRoom<
         this._clearTimeout(this._timeouts.reconnect);
 
         this._detachWindowListeners();
+
         this._usersManager.removeMyself();
+        this._usersManager.removeUsers();
+        this._otherNotifier.clear();
+        this._stateNotifier.subjects.myself.next(null);
+        this._stateNotifier.subjects.others.next([]);
 
         const canClose = [WebSocket.CONNECTING, WebSocket.OPEN].some(
             (readyState) => readyState === this._state.webSocket?.readyState,

--- a/packages/client/src/UsersManager.ts
+++ b/packages/client/src/UsersManager.ts
@@ -85,6 +85,10 @@ export class UsersManager<TIO extends IOLike, TPresence extends JsonObject = {}>
         this._others.delete(connectionId);
     }
 
+    public removeUsers(): void {
+        this._others.clear();
+    }
+
     public setMyself(connectionId: string, user: Id<InferIOAuthorizeUser<InferIOAuthorize<TIO>>>): void {
         this._myself = {
             connectionId,


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

When the websocket connection is closed, clear stateful information for others and the user.