### PR TITLE
fix(io): fix message event on recieve

### DIFF
--- a/.changeset/early-seas-live.md
+++ b/.changeset/early-seas-live.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": patch
+---
+
+Fix IORoom onRoomMessage event triggering on message sent instead of on message received.

--- a/packages/io/src/AbstractPlatform.ts
+++ b/packages/io/src/AbstractPlatform.ts
@@ -47,6 +47,8 @@ export abstract class AbstractPlatform<
     public persistance: AbstractPersistance;
     public pubSub: AbstractPubSub;
 
+    public readonly _meta: any = undefined;
+
     public abstract readonly _registrationMode: WebSocketRegistrationMode;
 
     constructor(config: AbstractPlatformConfig<TPlatformContext, TRoomContext> = {}) {


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fix `IORoom` `onRoomMessage` event being triggered on message sent instead of message received.