### PR TITLE
refactor(io): add crdt-library-type

### DIFF
--- a/.changeset/fast-monkeys-admire.md
+++ b/.changeset/fast-monkeys-admire.md
@@ -1,0 +1,7 @@
+---
+"@pluv/crdt-loro": patch
+"@pluv/crdt-yjs": patch
+"@pluv/io": patch
+---
+
+Added `CrdtLibraryType` so that `@pluv/crdt-yjs` and `@pluv/crdt-loro` export a new property `kind` containing an identifier for the crdt.

--- a/packages/crdt-loro/src/loro.ts
+++ b/packages/crdt-loro/src/loro.ts
@@ -4,3 +4,4 @@ export { map } from "./map";
 export { object } from "./object";
 export { text } from "./text";
 export type { LoroType } from "./types";
+export const kind = "loro" as const;

--- a/packages/crdt-yjs/src/yjs.ts
+++ b/packages/crdt-yjs/src/yjs.ts
@@ -7,3 +7,4 @@ export type { YjsType } from "./types";
 export { xmlElement } from "./xmlElement";
 export { xmlFragment } from "./xmlFragment";
 export { xmlText } from "./xmlText";
+export const kind = "yjs" as const;

--- a/packages/io/src/PluvIO.ts
+++ b/packages/io/src/PluvIO.ts
@@ -1,14 +1,14 @@
 import type { AbstractCrdtDocFactory } from "@pluv/crdt";
 import { noop } from "@pluv/crdt";
 import type { BaseIOAuthorize, IOAuthorize, InferIOAuthorizeUser, JsonObject } from "@pluv/types";
-import type { AbstractPlatform, InferPlatformContextType, WebSocketRegistrationMode } from "./AbstractPlatform";
+import type { AbstractPlatform, InferPlatformContextType } from "./AbstractPlatform";
 import { PluvProcedure } from "./PluvProcedure";
 import type { MergedRouter, PluvRouterEventConfig } from "./PluvRouter";
 import { PluvRouter } from "./PluvRouter";
 import { PluvServer } from "./PluvServer";
 import type { JWTEncodeParams } from "./authorize";
 import { authorize } from "./authorize";
-import type { GetInitialStorageFn, PluvIOListeners } from "./types";
+import type { CrdtLibraryType, GetInitialStorageFn, PluvIOListeners } from "./types";
 import { __PLUV_VERSION } from "./version";
 
 export type PluvIOConfig<
@@ -18,7 +18,7 @@ export type PluvIOConfig<
 > = {
     authorize?: TAuthorize;
     context?: TContext;
-    crdt?: { doc: (value: any) => AbstractCrdtDocFactory<any> };
+    crdt?: CrdtLibraryType;
     debug?: boolean;
     platform: TPlatform;
 };

--- a/packages/io/src/PluvServer.ts
+++ b/packages/io/src/PluvServer.ts
@@ -11,12 +11,7 @@ import type {
     Maybe,
 } from "@pluv/types";
 import colors from "kleur";
-import type {
-    AbstractPlatform,
-    InferPlatformContextType,
-    InferRoomContextType,
-    WebSocketRegistrationMode,
-} from "./AbstractPlatform";
+import type { AbstractPlatform, InferPlatformContextType, InferRoomContextType } from "./AbstractPlatform";
 import type { IORoomListeners } from "./IORoom";
 import { IORoom } from "./IORoom";
 import { PluvProcedure } from "./PluvProcedure";

--- a/packages/io/src/createIO.ts
+++ b/packages/io/src/createIO.ts
@@ -1,8 +1,7 @@
-import type { AbstractCrdtDocFactory } from "@pluv/crdt";
 import type { BaseUser, IOAuthorize, JsonObject } from "@pluv/types";
 import type { AbstractPlatform, InferPlatformContextType } from "./AbstractPlatform";
 import { PluvIO } from "./PluvIO";
-import type { GetInitialStorageFn } from "./types";
+import { CrdtLibraryType } from "./types";
 
 export type CreateIOParams<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
@@ -12,7 +11,7 @@ export type CreateIOParams<
 > = {
     authorize?: IOAuthorize<TAuthorizeUser, TAuthorizeRequired, InferPlatformContextType<TPlatform>>;
     context?: TContext;
-    crdt?: { doc: (value: any) => AbstractCrdtDocFactory<any> };
+    crdt?: CrdtLibraryType;
     debug?: boolean;
     platform: TPlatform;
 };

--- a/packages/io/src/index.ts
+++ b/packages/io/src/index.ts
@@ -35,6 +35,8 @@ export type { MergedRouter, PluvRouterEventConfig } from "./PluvRouter";
 export { PluvServer } from "./PluvServer";
 export type { CreateRoomOptions, InferIORoom, PluvServerConfig } from "./PluvServer";
 export type {
+    CrdtLibraryType,
+    GetInitialStorageFn,
     IORoomListenerEvent,
     IORoomMessageEvent,
     PluvIOListeners,

--- a/packages/io/src/types.ts
+++ b/packages/io/src/types.ts
@@ -1,4 +1,4 @@
-import type { AbstractCrdtDoc } from "@pluv/crdt";
+import type { AbstractCrdtDoc, AbstractCrdtDocFactory } from "@pluv/crdt";
 import type {
     BaseIOAuthorize,
     EventRecord,
@@ -24,6 +24,11 @@ declare global {
     var console: {
         log: (...data: any[]) => void;
     };
+}
+
+export interface CrdtLibraryType {
+    doc: (value: any) => AbstractCrdtDocFactory<any>;
+    kind: "loro" | "yjs";
 }
 
 export type EventResolver<


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Added `CrdtLibraryType`. Updated `@pluv/crdt-yjs` and `@pluv/crdt-loro` to expose a property `kind` that identifies the crdt type.