### PR TITLE
feat(io): expose websocket on events

### DIFF
--- a/.changeset/twelve-lies-tickle.md
+++ b/.changeset/twelve-lies-tickle.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": patch
+---
+
+Update `onRoomMessage` and `onStorageUpdated` events to include the WebSocket as part of the `event` parameter of those listeners.

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -606,6 +606,7 @@ export class IORoom<
                 message: message as InferEventMessage<InferEventsOutput<TEvents>, keyof InferEventsOutput<TEvents>>,
                 room: this.id,
                 user: session.user,
+                webSocket: session.webSocket.webSocket,
             });
 
             const sessionId = session.id;

--- a/packages/io/src/index.ts
+++ b/packages/io/src/index.ts
@@ -40,6 +40,7 @@ export type {
     GetInitialStorageFn,
     IORoomListenerEvent,
     IORoomMessageEvent,
+    IOStorageUpdatedEvent,
     PluvIOListeners,
     WebSocketSerializedState,
     WebSocketSession,

--- a/packages/io/src/types.ts
+++ b/packages/io/src/types.ts
@@ -18,7 +18,7 @@ import type {
     InferPlatformWebSocketType,
     InferRoomContextType,
 } from "./AbstractPlatform";
-import type { AbstractWebSocket } from "./AbstractWebSocket";
+import type { AbstractWebSocket, InferWebSocketSource } from "./AbstractWebSocket";
 import type { PluvRouterEventConfig } from "./PluvRouter";
 
 declare global {
@@ -122,7 +122,7 @@ export interface PluvIOListeners<
 > {
     onRoomDeleted: (event: IORoomListenerEvent<TPlatform, TAuthorize, TContext, TEvents>) => void;
     onRoomMessage: (event: IORoomMessageEvent<TPlatform, TAuthorize, TContext, TEvents>) => void;
-    onStorageUpdated: (event: IORoomListenerEvent<TPlatform, TAuthorize, TContext, TEvents>) => void;
+    onStorageUpdated: (event: IOStorageUpdatedEvent<TPlatform, TAuthorize, TContext, TEvents>) => void;
 }
 
 export type IORoomListenerEvent<
@@ -144,6 +144,17 @@ export type IORoomMessageEvent<
 > = IORoomListenerEvent<TPlatform, TAuthorize, TContext, TEvents> & {
     message: InferEventMessage<InferEventsOutput<TEvents>, keyof InferEventsOutput<TEvents>>;
     user?: InferIOAuthorizeUser<TAuthorize>;
+    webSocket?: InferPlatformWebSocketSource<TPlatform>;
+};
+
+export type IOStorageUpdatedEvent<
+    TPlatform extends AbstractPlatform<any>,
+    TAuthorize extends IOAuthorize<any, any, InferInitContextType<TPlatform>>,
+    TContext extends Record<string, any>,
+    TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>,
+> = IORoomListenerEvent<TPlatform, TAuthorize, TContext, TEvents> & {
+    user?: InferIOAuthorizeUser<TAuthorize>;
+    webSocket?: InferPlatformWebSocketSource<TPlatform>;
 };
 
 export type WebSocketType<TPlatform extends AbstractPlatform> =


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Expose websocket on `onRoomMessage` and `onStorageUpdated` events.