### PR TITLE
feat(io): get initial storage context

### DIFF
--- a/.changeset/cyan-jeans-tap.md
+++ b/.changeset/cyan-jeans-tap.md
@@ -1,0 +1,24 @@
+---
+"@pluv/io": patch
+---
+
+Update `getInitialStorage` so that the context is made available on the `context` event property.
+
+```ts
+import { createIO } from "@pluv/io";
+
+// Before
+const io = createIO({
+    getInitialStorage: ({ room, ...context }) => {
+        // ...
+    },
+});
+
+// After
+const io = createIO({
+    // Context is now an explicit property on the event
+    getInitialStorage: ({ room, context }) => {
+        // ...
+    },
+});
+```

--- a/apps/web/src/inputs/docs/@pluv_io/Cloudflare Workers.mdx
+++ b/apps/web/src/inputs/docs/@pluv_io/Cloudflare Workers.mdx
@@ -53,7 +53,7 @@ export const io = createIO({
 
 export const ioServer = io.server({
     // Example of using Cloudflare's D1 database with drizzle-orm
-    getInitialStorage: async ({ env, room }) => {
+    getInitialStorage: async ({ context: { env }, room }) => {
         const db = drizzle(env.DB, { schema });
 
         const existingRoom = await db

--- a/packages/io/src/PluvIO.ts
+++ b/packages/io/src/PluvIO.ts
@@ -29,7 +29,7 @@ export type ServerConfig<
     TContext extends Record<string, any> = {},
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
 > = Partial<PluvIOListeners<TPlatform, TAuthorize, TContext, TEvents>> & {
-    getInitialStorage?: GetInitialStorageFn;
+    getInitialStorage?: GetInitialStorageFn<TContext>;
     router?: PluvRouter<TPlatform, TAuthorize, TContext, TEvents>;
 };
 

--- a/packages/io/src/PluvServer.ts
+++ b/packages/io/src/PluvServer.ts
@@ -38,7 +38,7 @@ export type PluvServerConfig<
     context?: PluvContext<TPlatform, TContext>;
     crdt?: { doc: (value: any) => AbstractCrdtDocFactory<any> };
     debug?: boolean;
-    getInitialStorage?: GetInitialStorageFn;
+    getInitialStorage?: GetInitialStorageFn<TContext>;
     platform: TPlatform;
     router?: PluvRouter<TPlatform, TAuthorize, TContext, TEvents>;
 };
@@ -125,7 +125,7 @@ export class PluvServer<
                 const update = (data as any)?.update as Maybe<string>;
 
                 const updates: readonly Maybe<string>[] = [
-                    oldState ? null : await this._getInitialStorage?.({ ...context, room }),
+                    oldState ? null : await this._getInitialStorage?.({ context, room }),
                     update,
                 ];
 
@@ -197,7 +197,7 @@ export class PluvServer<
     private readonly _context: PluvContext<TPlatform, TContext> = {} as PluvContext<TPlatform, TContext>;
     private readonly _crdt: { doc: (value: any) => AbstractCrdtDocFactory<any> };
     private readonly _debug: boolean;
-    private readonly _getInitialStorage: GetInitialStorageFn | null = null;
+    private readonly _getInitialStorage: GetInitialStorageFn<TContext> | null = null;
     private readonly _platform: TPlatform;
     private readonly _router: PluvRouter<TPlatform, TAuthorize, TContext, TEvents>;
 

--- a/packages/io/src/types.ts
+++ b/packages/io/src/types.ts
@@ -106,11 +106,14 @@ export type MergeEventRecords<
       >
     : Id<TRoot>;
 
-export type GetInitialStorageEvent = {
+export type GetInitialStorageEvent<TContext extends Record<string, any>> = {
+    context: TContext;
     room: string;
 };
 
-export type GetInitialStorageFn = (event: GetInitialStorageEvent) => MaybePromise<Maybe<string>>;
+export type GetInitialStorageFn<TContext extends Record<string, any>> = (
+    event: GetInitialStorageEvent<TContext>,
+) => MaybePromise<Maybe<string>>;
 
 export interface PluvIOListeners<
     TPlatform extends AbstractPlatform<any>,

--- a/packages/platform-pluv/src/PluvIO.ts
+++ b/packages/platform-pluv/src/PluvIO.ts
@@ -35,7 +35,7 @@ type UserDisconnectedEventData<TUser extends BaseUser> = {
 };
 
 type PluvIOListeners<TUser extends BaseUser> = {
-    getInitialStorage?: GetInitialStorageFn;
+    getInitialStorage?: GetInitialStorageFn<{}>;
     onRoomDeleted: (event: RoomDeletedMessageEventData) => void;
     onUserConnected: (event: UserConnectedEventData<TUser>) => void;
     onUserDisconnected: (event: UserDisconnectedEventData<TUser>) => void;
@@ -66,7 +66,7 @@ export class PluvIO<TUser extends BaseUser> implements IOLike<PluvAuthorize<TUse
     private readonly _authorize: PluvAuthorize<TUser>;
     private readonly _basePath: string;
     private readonly _endpoints: PluvIOEndpoints;
-    private readonly _getInitialStorage?: GetInitialStorageFn;
+    private readonly _getInitialStorage?: GetInitialStorageFn<{}>;
     private readonly _listeners: PluvIOListeners<TUser>;
     private readonly _publicKey: string;
     private readonly _secretKey: string;
@@ -124,7 +124,10 @@ export class PluvIO<TUser extends BaseUser> implements IOLike<PluvAuthorize<TUse
         switch (event) {
             case "initial-storage": {
                 const room = data.room;
-                const storage = typeof room === "string" ? ((await this._getInitialStorage?.({ room })) ?? null) : null;
+                const storage =
+                    typeof room === "string"
+                        ? ((await this._getInitialStorage?.({ context: {}, room })) ?? null)
+                        : null;
 
                 return c.json({ data: { storage } }, 200);
             }


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Get initial storage context.