### PR TITLE
chore(crdt loro): update deprecated methods

### DIFF
--- a/.changeset/light-crews-invite.md
+++ b/.changeset/light-crews-invite.md
@@ -1,0 +1,5 @@
+---
+"@pluv/crdt-loro": patch
+---
+
+Update internal, deprecated `loro-crdt` methods.

--- a/packages/crdt-loro/src/doc/CrdtLoroDoc.ts
+++ b/packages/crdt-loro/src/doc/CrdtLoroDoc.ts
@@ -3,7 +3,7 @@ import { AbstractCrdtDoc } from "@pluv/crdt";
 import { fromUint8Array, toUint8Array } from "js-base64";
 import type { Container, LoroEventBatch } from "loro-crdt";
 import { LoroDoc, LoroList, LoroMap, LoroText, isContainer } from "loro-crdt";
-import type ZZ{ LoroType } from "../types";
+import type { LoroType } from "../types";
 
 export class CrdtLoroDoc<TStorage extends Record<string, LoroType<any, any>>> extends AbstractCrdtDoc<TStorage> {
     public value: LoroDoc = new LoroDoc();

--- a/packages/crdt-loro/src/doc/CrdtLoroDoc.ts
+++ b/packages/crdt-loro/src/doc/CrdtLoroDoc.ts
@@ -2,11 +2,11 @@ import type { DocApplyEncodedStateParams, DocSubscribeCallbackParams, InferCrdtJ
 import { AbstractCrdtDoc } from "@pluv/crdt";
 import { fromUint8Array, toUint8Array } from "js-base64";
 import type { Container, LoroEventBatch } from "loro-crdt";
-import { Loro, LoroList, LoroMap, LoroText, isContainer } from "loro-crdt";
-import { LoroType } from "../types";
+import { LoroDoc, LoroList, LoroMap, LoroText, isContainer } from "loro-crdt";
+import type { LoroType } from "../types";
 
 export class CrdtLoroDoc<TStorage extends Record<string, LoroType<any, any>>> extends AbstractCrdtDoc<TStorage> {
-    public value: Loro = new Loro();
+    public value: LoroDoc = new LoroDoc();
 
     private _storage: TStorage;
 
@@ -123,7 +123,7 @@ export class CrdtLoroDoc<TStorage extends Record<string, LoroType<any, any>>> ex
     }
 
     public getEncodedState(): string {
-        return fromUint8Array(this.value.exportSnapshot());
+        return fromUint8Array(this.value.export({ mode: "snapshot" }));
     }
 
     public toJson(): InferCrdtJson<TStorage>;
@@ -160,7 +160,8 @@ export class CrdtLoroDoc<TStorage extends Record<string, LoroType<any, any>>> ex
 
     public subscribe(listener: (params: DocSubscribeCallbackParams<TStorage>) => void): () => void {
         const fn = (event: LoroEventBatch) => {
-            const update = fromUint8Array(this.value.exportFrom());
+            const version = this.value.oplogVersion();
+            const update = fromUint8Array(this.value.export({ mode: "update", from: version }));
 
             listener({
                 doc: this,

--- a/packages/crdt-loro/src/doc/CrdtLoroDoc.ts
+++ b/packages/crdt-loro/src/doc/CrdtLoroDoc.ts
@@ -3,7 +3,7 @@ import { AbstractCrdtDoc } from "@pluv/crdt";
 import { fromUint8Array, toUint8Array } from "js-base64";
 import type { Container, LoroEventBatch } from "loro-crdt";
 import { LoroDoc, LoroList, LoroMap, LoroText, isContainer } from "loro-crdt";
-import type { LoroType } from "../types";
+import type ZZ{ LoroType } from "../types";
 
 export class CrdtLoroDoc<TStorage extends Record<string, LoroType<any, any>>> extends AbstractCrdtDoc<TStorage> {
     public value: LoroDoc = new LoroDoc();
@@ -160,8 +160,7 @@ export class CrdtLoroDoc<TStorage extends Record<string, LoroType<any, any>>> ex
 
     public subscribe(listener: (params: DocSubscribeCallbackParams<TStorage>) => void): () => void {
         const fn = (event: LoroEventBatch) => {
-            const version = this.value.oplogVersion();
-            const update = fromUint8Array(this.value.export({ mode: "update", from: version }));
+            const update = fromUint8Array(this.value.export({ mode: "update" }));
 
             listener({
                 doc: this,


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Update internal, deprecated loro-crdt methods.