### PR TITLE
feat(react): remove re-exports of client and crdt from react

### DIFF
--- a/.changeset/eight-parents-cheer.md
+++ b/.changeset/eight-parents-cheer.md
@@ -1,0 +1,19 @@
+---
+"@pluv/react": minor
+---
+
+**BREAKING**
+
+Removed re-exports of `@pluv/client` and `@pluv/crdt` parts from `@pluv/react`.
+
+```ts
+// Before
+
+import { createBundle, createClient } from "@pluv/react";
+
+// After
+
+import { createClient } from "@pluv/client";
+import { createBundle } from "@pluv/react";
+
+```

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,6 +1,3 @@
-export { ConnectionState, createClient, register } from "@pluv/client";
-export type { CrdtType, InferCrdtJson } from "@pluv/crdt";
-export type { BaseUser, EventMessage, EventRecord, IOEventMessage } from "@pluv/types";
 export { createBundle } from "./createBundle";
 export type {
     CreateBundle,


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Remove re-exports of `@pluv/client` and `@pluv/crdt` parts from `@pluv/react`.