### PR TITLE
feat(client): update default ws endpoint

### DIFF
--- a/.changeset/chatty-ears-run.md
+++ b/.changeset/chatty-ears-run.md
@@ -1,0 +1,5 @@
+---
+"@pluv/client": patch
+---
+
+Updated the default `wsEndpoint` for `PluvClient` when `publicKey` is provided to be correct.

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -747,7 +747,7 @@ export class PluvRoom<
     private _getWsEndpoint(room: string): string {
         switch (typeof this._endpoints.wsEndpoint) {
             case "undefined":
-                return `/api/pluv/room/${room}`;
+                return !!this._getPublicKey() ? `https://rooms.pluv.io/${room}` : `/api/pluv/room/${room}`;
             case "string":
                 return this._endpoints.wsEndpoint;
             default:


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Update the default `wsEndpoint` when `publicKey` is provided.