### PR TITLE
feat(react): add missing room error message

### DIFF
--- a/.changeset/cold-sites-shout.md
+++ b/.changeset/cold-sites-shout.md
@@ -1,0 +1,5 @@
+---
+"@pluv/react": patch
+---
+
+Added an error message for when `createBundle` functions are used outside of `PluvRoomProvider`.

--- a/packages/react/src/createBundle.tsx
+++ b/packages/react/src/createBundle.tsx
@@ -246,7 +246,13 @@ export const createBundle = <
 
     const useClient = (): PluvClient<TIO, TPresence, TStorage, TMetadata> => useContext(PluvContext);
 
-    const useRoom = () => useContext(PluvRoomContext);
+    const useRoom = () => {
+        const room = useContext(PluvRoomContext);
+
+        if (!room) throw new Error("Room could not be found. Component must be wrapped with PluvRoomProvider");
+
+        return room;
+    };
 
     const useBroadcast = (): BroadcastProxy<MergeEvents<TEvents, TIO>> => {
         const room = useRoom();


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Added error message about missing room if `PluvRoomProvider` was not used.