### PR TITLE
fix(platform cloudflare): fix auto ws response

### DIFF
--- a/.changeset/itchy-ads-type.md
+++ b/.changeset/itchy-ads-type.md
@@ -1,0 +1,5 @@
+---
+"@pluv/platform-cloudflare": patch
+---
+
+Fix sending and receiving the wrong heartbeat websocket events for Cloudflare websocket hibernation.

--- a/packages/platform-cloudflare/src/CloudflarePlatform.ts
+++ b/packages/platform-cloudflare/src/CloudflarePlatform.ts
@@ -77,7 +77,7 @@ export class CloudflarePlatform<
         if (!detachedState) return;
 
         detachedState.setWebSocketAutoResponse(
-            new WebSocketRequestResponsePair('{"type":"$PING","data":{}}', JSON.stringify({ type: "$PONG", data: {} })),
+            new WebSocketRequestResponsePair('{"type":"$ping","data":{}}', JSON.stringify({ type: "$pong", data: {} })),
         );
     }
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fix sending incorrect heartbeat event auto-responses for Cloudflare's WebSocket hibernation.