### PR TITLE
feat(io): valid event names

### DIFF
--- a/.changeset/violet-files-scream.md
+++ b/.changeset/violet-files-scream.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": patch
+---
+
+Require `PluvRouter` event names to be formatted as valid JavaScript variable names.

--- a/packages/io/src/PluvRouter.ts
+++ b/packages/io/src/PluvRouter.ts
@@ -32,6 +32,14 @@ export class PluvRouter<
     readonly _defs: { events: TEvents } = { events: {} as TEvents };
 
     constructor(events: TEvents) {
+        const invalidName = Object.keys(events).find((name) => !this._isValidEventName(name));
+
+        if (typeof invalidName === "string") {
+            throw new Error(
+                `Invalid event name. Event names must be formatted as valid JavaScript variable names: "${invalidName}"`,
+            );
+        }
+
         this._defs = { events };
     }
 
@@ -41,5 +49,9 @@ export class PluvRouter<
         const events = Object.assign(Object.create(null), ...routers.map((router) => router._defs.events));
 
         return new PluvRouter<any, any, any, any>(events) as MergedRouter<TRouters>;
+    }
+
+    private _isValidEventName(name: string): boolean {
+        return /^[a-z_$][a-z0-9_$]*$/gi.test(name);
     }
 }


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Require `PluvRouter` event names to be formatted as valid JavaScript variable names.