### PR TITLE
fix(platform-pluv): undefined event call again

### DIFF
--- a/.changeset/proud-gifts-boil.md
+++ b/.changeset/proud-gifts-boil.md
@@ -1,0 +1,5 @@
+---
+"@pluv/platform-pluv": patch
+---
+
+Fix `TypeError` on event handler invocations once again.

--- a/packages/platform-pluv/src/PluvPlatform.ts
+++ b/packages/platform-pluv/src/PluvPlatform.ts
@@ -185,9 +185,9 @@ export class PluvPlatform<
         this._authorize = config.authorize;
         this._getInitialStorage = config.getInitialStorage;
         this._listeners = {
-            onRoomDeleted: (event) => config.onRoomDeleted(event),
-            onUserConnected: (event) => config.onUserConnected(event),
-            onUserDisconnected: (event) => config.onUserDisconnected(event),
+            onRoomDeleted: (event) => config.onRoomDeleted?.(event),
+            onUserConnected: (event) => config.onUserConnected?.(event),
+            onUserDisconnected: (event) => config.onUserDisconnected?.(event),
         };
     }
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fix `TypeError` on event handler invocations once again.