### PR TITLE
feat(client): local only presence updates

### DIFF
--- a/.changeset/fast-seals-build.md
+++ b/.changeset/fast-seals-build.md
@@ -1,0 +1,5 @@
+---
+"@pluv/client": patch
+---
+
+Update the user's presence locally only via `PluvRoom.updateMyPresence` (i.e. do not update the user's own presence from WebSocket messages) to avoid update delays. This should fix some cases of "jitter" depending on network latecy.

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -785,12 +785,14 @@ export class PluvRoom<
         const myPresence = this._usersManager.myPresence;
         const myself = this._usersManager.myself ?? null;
 
-        if (myself?.connectionId === connectionId) {
-            this._stateNotifier.subjects["my-presence"].next(myPresence);
-            this._stateNotifier.subjects["myself"].next(myself);
-
-            return;
-        }
+        /**
+         * !HACK
+         * @description We're going to have the user's own presence be patched only via local calls
+         * to this.updateMyPresence. So we'll not update the user's presence in this handler to
+         * avoid weird update delays to the user's own presence.
+         * @date April 2, 2025
+         */
+        if (myself?.connectionId === connectionId) return;
 
         const other = this._usersManager.getOther(connectionId);
         const others = this._usersManager.getOthers();


### PR DESCRIPTION
## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [ ] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Update the user's presence locally only via `PluvRoom.updateMyPresence` (i.e. do not update the user's own presence from WebSocket messages) to avoid update delays. This should fix some cases of "jitter" depending on network latecy.