### PR TITLE
fix(io): fix default router types

### DIFF
--- a/.changeset/odd-hotels-strive.md
+++ b/.changeset/odd-hotels-strive.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": patch
+---
+
+Fix generic type default for router events.

--- a/packages/io/src/PluvIO.ts
+++ b/packages/io/src/PluvIO.ts
@@ -115,7 +115,7 @@ export class PluvIO<
         return new PluvRouter<TPlatform, TAuthorize, TContext, TEvents>(events);
     }
 
-    public server<TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>>(
+    public server<TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {}>(
         config: ServerConfig<TPlatform, TAuthorize, TContext, TEvents> = {} as ServerConfig<
             TPlatform,
             TAuthorize,


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fix generic type default for router events on `PluvIO.server`.