### PR TITLE
fix(client): improve connection handling

### DIFF
--- a/.changeset/bright-nights-read.md
+++ b/.changeset/bright-nights-read.md
@@ -1,0 +1,5 @@
+---
+"@pluv/client": patch
+---
+
+Improved handling of polling-reconnects to `PluvRoom` after the websocket closes (depending on the close event's code).

--- a/.changeset/gold-areas-brake.md
+++ b/.changeset/gold-areas-brake.md
@@ -1,0 +1,5 @@
+---
+"@pluv/react": patch
+---
+
+Fixed potential race conditions between connecting and disconnecting between re-renders of `PluvRoomProvider`.

--- a/.changeset/strong-banks-clean.md
+++ b/.changeset/strong-banks-clean.md
@@ -1,0 +1,21 @@
+---
+"@pluv/client": minor
+---
+
+**BREAKING** Moved the `metadata` parameter from the constructor of `PluvRoom` to `PluvClient.connect`. The `metadata` parameter from the constructor of `PluvRoom` is now the validation schema for `metadata` passed through from `PluvClient`.
+
+This should not be breaking for most users, as the recommended way to enter a room has always been via `PluvClient.enter(room)` (i.e. these are mostly internal-only changes).
+
+```ts
+// Before
+const room = new Room("my-room", { metadata: { hello: "world" } });
+
+await room.connect();
+
+// After
+const room = new Room("my-room", {
+    metadata: z.object({ hello: z.string() }),
+});
+
+await room.connect({ metadata: { hello: "world" } });
+```

--- a/.changeset/wet-planes-invent.md
+++ b/.changeset/wet-planes-invent.md
@@ -1,0 +1,5 @@
+---
+"@pluv/react": patch
+---
+
+(Internal) Update how `PluvRoomProvider` handles the `metadata` prop internally to be updated to how `PluvClient` now handles this (i.e. moved to `PluvClient.enter`, from `PluvClient.createRoom`).

--- a/.changeset/wicked-walls-attack.md
+++ b/.changeset/wicked-walls-attack.md
@@ -1,0 +1,22 @@
+---
+"@pluv/react": patch
+---
+
+Add support for a passing either a function or object for the `metadata` prop on `PluvRoomProvider`. When a function is used, the `metadata` will be gotten at the moment of connection (internally this is a `useEffect`, so browser APIs can be used such as `document`, `window` and `localStorage`).
+
+```tsx
+// Both of these work
+<PluvRoomProvider metadata={{ hello: "world" }}>
+    {children}
+</PluvRoomProvider>
+
+<PluvRoomProvider
+    metadata={() => {
+        const value = localStorage.get(MY_LOCALSTORAGE_KEY);
+
+        return { hello: value };
+    }}
+>
+    {children}
+</PluvRoomProvider>
+```

--- a/.changeset/wide-pandas-give.md
+++ b/.changeset/wide-pandas-give.md
@@ -1,0 +1,23 @@
+---
+"@pluv/client": minor
+---
+
+**BREAKING** Moved the `metadata` parameter from `PluvClient.createRoom` to `PluvClient.enter`.
+
+```ts
+// Before
+const room = client.createRoom({
+    // ...
+    metadata: { hello: "world" },
+    // ...
+});
+
+client.enter(room);
+
+// After
+const room = client.createRoom({
+    // ...
+});
+
+client.enter(room, { metadata });
+```

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -23,4 +23,4 @@ export type {
 export type { MergeEvents, PluvRouter, PluvRouterEventConfig } from "./PluvRouter";
 export { register } from "./register";
 export type { RegisterParams } from "./register";
-export type { PublicKey, PublicKeyParams, UserInfo, WebSocketConnection, WebSocketState } from "./types";
+export type { InferMetadata, PublicKey, PublicKeyParams, UserInfo, WebSocketConnection, WebSocketState } from "./types";

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -9,10 +9,17 @@ export type { InferCallback } from "./infer";
 export { MockedRoom } from "./MockedRoom";
 export type { MockedRoomConfig, MockedRoomEvents } from "./MockedRoom";
 export { PluvClient } from "./PluvClient";
-export type { CreateRoomOptions, PluvClientOptions } from "./PluvClient";
+export type { CreateRoomOptions, EnterRoomParams, PluvClientOptions } from "./PluvClient";
 export type { PluvProcedureConfig } from "./PluvProcedure";
 export { PluvRoom } from "./PluvRoom";
-export type { PluvRoomAddon, PluvRoomAddonInput, PluvRoomAddonResult, PluvRoomDebug, RoomEndpoints } from "./PluvRoom";
+export type {
+    PluvRoomAddon,
+    PluvRoomAddonInput,
+    PluvRoomAddonResult,
+    PluvRoomDebug,
+    RoomConnectParams,
+    RoomEndpoints,
+} from "./PluvRoom";
 export type { MergeEvents, PluvRouter, PluvRouterEventConfig } from "./PluvRouter";
 export { register } from "./register";
 export type { RegisterParams } from "./register";

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -79,3 +79,7 @@ export interface WebSocketState<TIO extends IOLike> {
     connection: WebSocketConnection;
     webSocket: WebSocket | null;
 }
+
+export type WithMetadata<TMetadata extends JsonObject = {}> = keyof TMetadata extends never
+    ? { metadata?: undefined }
+    : { metadata: TMetadata };

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -9,6 +9,7 @@ import type {
     MaybePromise,
 } from "@pluv/types";
 import type { ConnectionState } from "./enums";
+import type { PluvClient } from "./PluvClient";
 
 export interface AuthorizationState<TIO extends IOLike> {
     token: string | null;
@@ -33,6 +34,9 @@ export interface EventResolverContext<
     room: string;
     user: UserInfo<TIO, TPresence>;
 }
+
+export type InferMetadata<TClient extends PluvClient<any, any, any, any>> =
+    TClient extends PluvClient<any, any, any, infer IMetadata> ? IMetadata : never;
 
 export interface InternalSubscriptions {
     observeCrdt: (() => void) | null;

--- a/packages/react/src/internal/hooks/index.ts
+++ b/packages/react/src/internal/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useAsyncQueue } from "./useAsyncQueue";
 export { useNoSsr } from "./useNoSsr";
 export { useRerender } from "./useRerender";
 export { useSyncExternalStoreWithSelector } from "./useSyncExternalStoreWithSelector";

--- a/packages/react/src/internal/hooks/index.ts
+++ b/packages/react/src/internal/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useAsyncQueue } from "./useAsyncQueue";
+export { useDeepAsyncMemo } from "./useDeepAsyncMemo";
 export { useNoSsr } from "./useNoSsr";
 export { useRerender } from "./useRerender";
 export { useSyncExternalStoreWithSelector } from "./useSyncExternalStoreWithSelector";

--- a/packages/react/src/internal/hooks/useAsyncQueue.ts
+++ b/packages/react/src/internal/hooks/useAsyncQueue.ts
@@ -1,0 +1,18 @@
+import { useCallback, useMemo, useRef } from "react";
+
+/**
+ * @description This is to handle race conditions, so that our async operations that can
+ * happen between re-renders will happen sequentially.
+ * @date April 13, 2025
+ */
+export const useAsyncQueue = () => {
+    const queueRef = useRef<Promise<void>>(Promise.resolve(undefined));
+
+    const push = useCallback(async (promise: Promise<void>) => {
+        queueRef.current = queueRef.current.then(async () => await promise);
+
+        return await queueRef.current;
+    }, []);
+
+    return useMemo(() => ({ push }), [push]);
+};

--- a/packages/react/src/internal/hooks/useAsyncQueue.ts
+++ b/packages/react/src/internal/hooks/useAsyncQueue.ts
@@ -8,7 +8,7 @@ import { useCallback, useMemo, useRef } from "react";
 export const useAsyncQueue = () => {
     const queueRef = useRef<Promise<void>>(Promise.resolve(undefined));
 
-    const push = useCallback(async (promise: Promise<void>) => {
+    const push = useCallback(async (promise: Promise<any>) => {
         queueRef.current = queueRef.current.then(async () => await promise);
 
         return await queueRef.current;

--- a/packages/react/src/internal/hooks/useDeepAsyncMemo.ts
+++ b/packages/react/src/internal/hooks/useDeepAsyncMemo.ts
@@ -70,6 +70,7 @@ export const useDeepAsyncMemo = <T>(
                     setState((prev) => {
                         return {
                             ...prev,
+                            isInitialized: true,
                             isLoading: false,
                         } as UseDeepAsyncMemoResult<T>;
                     });

--- a/packages/react/src/internal/hooks/useDeepAsyncMemo.ts
+++ b/packages/react/src/internal/hooks/useDeepAsyncMemo.ts
@@ -104,7 +104,17 @@ export const useDeepAsyncMemo = <T>(
         return () => {
             isMountedRef.current = false;
         };
-    }, [factory, isEqual]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+        /**
+         * !HACK
+         * @description We're only going to use the `isEqual` function to determine if this hook
+         * should re-run. This is basically our hook's version of a dependency array
+         * @date April 13, 2025
+         */
+        // factory,
+        isEqual,
+    ]);
 
     return state;
 };

--- a/packages/react/src/internal/hooks/useDeepAsyncMemo.ts
+++ b/packages/react/src/internal/hooks/useDeepAsyncMemo.ts
@@ -1,0 +1,109 @@
+import { useEffect, useRef, useState } from "react";
+import fastDeepEqual from "fast-deep-equal";
+
+export type UseDeepAsyncMemoResult<T extends unknown> =
+    | {
+          error: null;
+          isInitialized: true;
+          isLoading: false;
+          value: T;
+      }
+    | {
+          error: null;
+          isInitialized: boolean;
+          value: undefined;
+          isLoading: true;
+      }
+    | {
+          error: Error;
+          isInitialized: boolean;
+          value: undefined;
+          isLoading: false;
+      };
+
+export const useDeepAsyncMemo = <T>(
+    factory: () => Promise<T>,
+    isEqual: (a: T, b: T) => boolean = fastDeepEqual,
+): UseDeepAsyncMemoResult<T> => {
+    // Store the current async state (loading, value, error, etc.)
+    const [state, setState] = useState<UseDeepAsyncMemoResult<T>>({
+        isInitialized: false,
+        isLoading: true,
+        value: undefined,
+        error: null,
+    });
+
+    // Keep track of the last resolved value to compare with new ones
+    const lastValueRef = useRef<T | undefined>(undefined);
+    const hasValueRef = useRef(false); // Tracks whether we've ever resolved a value
+
+    // Tracks the current in-flight promise to guard against race conditions
+    const inflightRef = useRef<Promise<T> | null>(null);
+
+    // Used to prevent state updates after the component unmounts
+    const isMountedRef = useRef(true);
+
+    useEffect(() => {
+        isMountedRef.current = true;
+
+        // Trigger the async factory
+        const promise = factory();
+        inflightRef.current = promise;
+
+        // Set loading state
+        setState((prev) => {
+            return {
+                ...prev,
+                isLoading: true,
+                error: null,
+            } as UseDeepAsyncMemoResult<T>;
+        });
+
+        promise
+            .then((result) => {
+                // Ignore if component unmounted or if this promise is stale
+                if (!isMountedRef.current || inflightRef.current !== promise) return;
+
+                // Skip update if value hasn't changed
+                const isSame = hasValueRef.current && isEqual(lastValueRef.current as T, result);
+                if (isSame) {
+                    setState((prev) => {
+                        return {
+                            ...prev,
+                            isLoading: false,
+                        } as UseDeepAsyncMemoResult<T>;
+                    });
+                    return;
+                }
+
+                // Save the new value
+                lastValueRef.current = result;
+                hasValueRef.current = true;
+
+                setState({
+                    isInitialized: true,
+                    isLoading: false,
+                    value: result,
+                    error: null,
+                });
+            })
+            .catch((err) => {
+                // Ignore if component unmounted or if this promise is stale
+                if (!isMountedRef.current || inflightRef.current !== promise) return;
+
+                setState({
+                    isInitialized: hasValueRef.current,
+                    isLoading: false,
+                    value: undefined,
+                    error: err instanceof Error ? err : new Error("Unknown error"),
+                });
+            });
+
+        // Cleanup: prevent state updates after unmount
+        return () => {
+            isMountedRef.current = false;
+        };
+    }, [factory, isEqual]);
+
+    return state;
+};

--- a/packages/react/src/internal/index.ts
+++ b/packages/react/src/internal/index.ts
@@ -1,2 +1,2 @@
-export { useAsyncQueue, useRerender, useSyncExternalStoreWithSelector } from "./hooks";
+export { useAsyncQueue, useDeepAsyncMemo, useRerender, useSyncExternalStoreWithSelector } from "./hooks";
 export { identity, shallowArrayEqual } from "./utils";

--- a/packages/react/src/internal/index.ts
+++ b/packages/react/src/internal/index.ts
@@ -1,2 +1,2 @@
-export { useRerender, useSyncExternalStoreWithSelector } from "./hooks";
+export { useAsyncQueue, useRerender, useSyncExternalStoreWithSelector } from "./hooks";
 export { identity, shallowArrayEqual } from "./utils";


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

* `client`: Handle additional edge-cases for polling reconnects.
* `client`: Move metadata from `PluvClient.createRoom` to `PluvRoom.connect` (and in turn `PluvClient.enter`).
* `react`: Update `PluvRoomProvider` so that metadata usage internally is updated to how `PluvClient` now handles metadata (i.e. moving it to `PluvClient.enter`.
* `react`: Update `PluvRoomProvider` to have an additional optional `boolean` prop `connect` (default = `true`), which can be set to `false` to prevent connecting to the room until it is set to true.
* `react` Fix potential race conditions of entering and leaving the room during re-renders.