### PR TITLE
feat(client): reconnect timeout ms

### DIFF
--- a/.changeset/tender-queens-lead.md
+++ b/.changeset/tender-queens-lead.md
@@ -1,0 +1,23 @@
+---
+"@pluv/client": patch
+---
+
+Add the ability to configure the reconnect timeout (in milliseconds) for a `PluvRoom`, and lowered the default reconnect timeout from 30s to 5s. Values will be automatically clamped to between 1s and 60s.
+
+```ts
+// Both of these are valid
+const room = client.createRoom("my-room", {
+    // Set timeout to a fixed 10s
+    reconnectTimeoutMs: 10_000,
+});
+
+const room = client.createRoom("my-room", {
+    /**
+     * `attempts` is the count of failed reconnect attempts, starting from 0 on the first attempt.
+     * The returned value will be how long until the next attempt.
+     */
+    reconnectTimeoutMs: ({ attempts }) => {
+        return 10_000 + (1_000 * Math.pow(2, attempts));
+    },
+});
+```

--- a/packages/client/src/MockedRoom.ts
+++ b/packages/client/src/MockedRoom.ts
@@ -59,6 +59,7 @@ export class MockedRoom<
             user: null,
         },
         connection: {
+            attempts: 0,
             count: 1,
             id: null,
             state: ConnectionState.Untouched,

--- a/packages/client/src/PluvClient.ts
+++ b/packages/client/src/PluvClient.ts
@@ -4,9 +4,9 @@ import type { InferCallback } from "./infer";
 import { PluvProcedure } from "./PluvProcedure";
 import type {
     AuthEndpoint,
-    RoomConnectParams,
     PluvRoomAddon,
     PluvRoomDebug,
+    ReconnectTimeoutMs,
     RoomConfig,
     RoomEndpoints,
     WsEndpoint,
@@ -42,6 +42,7 @@ export type CreateRoomOptions<
     initialPresence?: TPresence;
     initialStorage?: AbstractCrdtDocFactory<TStorage>;
     onAuthorizationFail?: (error: Error) => void;
+    reconnectTimeoutMs?: ReconnectTimeoutMs;
     router?: PluvRouter<TIO, TPresence, TStorage, TEvents>;
 };
 
@@ -107,6 +108,7 @@ export class PluvClient<
             onAuthorizationFail: options.onAuthorizationFail,
             presence: this._presence,
             publicKey: this._publicKey ?? undefined,
+            reconnectTimeoutMs: options.reconnectTimeoutMs,
             router: options.router,
             wsEndpoint: this._wsEndpoint,
         } as RoomConfig<TIO, TMetadata, TPresence, TStorage, TEvents>);

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -48,7 +48,11 @@ import { debounce } from "./utils";
 const ADD_TO_STORAGE_STATE_DEBOUNCE_MS = 1_000;
 const HEARTBEAT_INTERVAL_MS = 10_000;
 const PONG_TIMEOUT_MS = 2_000;
+
 const RECONNECT_TIMEOUT_MS = 5_000;
+const MIN_RECONNECT_TIMEOUT_MS = 1_000;
+const MAX_RECONNECT_TIMEOUT_MS = 60_000;
+
 const ORIGIN_INITIALIZED = "$initialized";
 const ORIGIN_STORAGE_UPDATED = "$storageUpdated";
 
@@ -1214,8 +1218,9 @@ export class PluvRoom<
             typeof this._reconnectTimeoutMs === "number"
                 ? this._reconnectTimeoutMs
                 : this._reconnectTimeoutMs({ attempts: this._state.connection.attempts });
+        const clampedMs = Math.max(Math.min(MIN_RECONNECT_TIMEOUT_MS, timeoutMs), MAX_RECONNECT_TIMEOUT_MS);
 
-        this._timeouts.reconnect = setTimeout(this._reconnect.bind(this), timeoutMs) as unknown as number;
+        this._timeouts.reconnect = setTimeout(this._reconnect.bind(this), clampedMs) as unknown as number;
     }
 
     private async _reconnect(): Promise<void> {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -73,6 +73,19 @@ export interface UserInfo<TIO extends IOLike, TPresence extends JsonObject = {}>
 }
 
 export interface WebSocketConnection {
+    /**
+     * @description How many times a connection attempt was made. This will increment upon each
+     * unsuccessful attempt, and will reset upon a successful connection.
+     * @date April 13, 2025
+     */
+    attempts: number;
+    /**
+     * @description How many times the user has connected to the room. This can be more than 1 in
+     * the case of reconnects. This is tracked because on the very first connection (i.e. when
+     * count is 0) we don't want to send the storage state as an update to the room and overwrite
+     * the upstream state.
+     * @date April 13, 2025
+     */
     count: number;
     id: string | null;
     state: ConnectionState;


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Added the ability to configure the reconnect timeout (in milliseconds) for a `PluvRoom`, and lowered the default reconnect timeout from 30s to 5s. Values will be automatically clamped to between 1s and 60s.