### PR TITLE
feat(client): optional create room options

### DIFF
--- a/.changeset/mighty-crabs-wink.md
+++ b/.changeset/mighty-crabs-wink.md
@@ -1,0 +1,5 @@
+---
+"@pluv/client": patch
+---
+
+Update `PluvClient.createRoom` so that the 2nd parameter is optional.

--- a/packages/client/src/PluvClient.ts
+++ b/packages/client/src/PluvClient.ts
@@ -92,7 +92,7 @@ export class PluvClient<
 
     public createRoom = <TEvents extends PluvRouterEventConfig<TIO, TPresence, TStorage> = {}>(
         room: string,
-        options: CreateRoomOptions<TIO, TPresence, TStorage, TMetadata, TEvents>,
+        options: CreateRoomOptions<TIO, TPresence, TStorage, TMetadata, TEvents> = {},
     ): PluvRoom<TIO, TMetadata, TPresence, TStorage, TEvents> => {
         const oldRoom = this.getRoom(room);
 
@@ -171,9 +171,8 @@ export class PluvClient<
     }
 
     private _logDebug(...data: any[]): void {
-        // eslint-disable-next-line turbo/no-undeclared-env-vars
         if (process?.env?.NODE_ENV === "production") return;
 
-        this._debug && console.log(...data);
+        if (this._debug) console.log(...data);
     }
 }


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Update the 2nd parameter of `PluvClient.createRoom` to be optional.