### PR TITLE
feat(client): attempt reconnect immediately after close

### DIFF
--- a/.changeset/hungry-colts-unite.md
+++ b/.changeset/hungry-colts-unite.md
@@ -1,0 +1,5 @@
+---
+"@pluv/client": patch
+---
+
+`PluvRoom` attempts to reconnect immediately after receiving a `close` event, instead of waiting for the reconnect timer. After failing the initial reconnect will the reconnects poll on the timer.

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -1066,11 +1066,6 @@ export class PluvRoom<
             1014,
         ].some((okToRetryCode) => event.code === okToRetryCode);
 
-        this._closeWs();
-
-        if (!shouldRetry) this._clearTimeout(this._timeouts.reconnect);
-        else this._pollReconnect();
-
         this._updateState((oldState) => {
             oldState.authorization.token = null;
             oldState.connection.state = shouldRetry ? ConnectionState.Unavailable : ConnectionState.Closed;
@@ -1078,6 +1073,14 @@ export class PluvRoom<
 
             return oldState;
         });
+
+        if (shouldRetry) {
+            await this._reconnect();
+            return;
+        }
+
+        this._closeWs();
+        this._clearTimeout(this._timeouts.reconnect);
     }
 
     /**


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Attempt to reconnect immediately after receiving a close event.