### PR TITLE
feat(io): in-memory user on websocket

### DIFF
--- a/.changeset/clever-ghosts-say.md
+++ b/.changeset/clever-ghosts-say.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": minor
+---
+
+**BREAKING** Updated the way `user` is stored and read from the websocket, so now `user` is persisted in-memory rather than from persistent storage (improves performance and lowers cost in some cases). This change primarily affects pluv platforms, which are intended for internal use only, and therefore should not be mostly non-breaking.

--- a/packages/io/src/AbstractPlatform.ts
+++ b/packages/io/src/AbstractPlatform.ts
@@ -29,7 +29,7 @@ export interface ConvertWebSocketConfig {
 }
 
 export abstract class AbstractPlatform<
-    TWebSocket extends AbstractWebSocket = AbstractWebSocket,
+    TWebSocket extends AbstractWebSocket<any, any> = AbstractWebSocket<any, any>,
     TInitContext extends Record<string, any> = {},
     TRoomContext extends Record<string, any> = {},
     TConfig extends PlatformConfig = PlatformConfig,
@@ -62,9 +62,9 @@ export abstract class AbstractPlatform<
     public abstract convertWebSocket(
         webSocket: InferWebSocketSource<TWebSocket>,
         config: ConvertWebSocketConfig,
-    ): AbstractWebSocket;
+    ): AbstractWebSocket<any, any>;
 
-    public abstract getLastPing(webSocket: AbstractWebSocket): number | null;
+    public abstract getLastPing(webSocket: AbstractWebSocket<any, any>): number | null;
 
     public abstract getSerializedState(webSocket: InferWebSocketSource<TWebSocket>): WebSocketSerializedState | null;
 

--- a/packages/io/src/PluvServer.ts
+++ b/packages/io/src/PluvServer.ts
@@ -27,7 +27,7 @@ export type InferIORoom<TServer extends PluvServer<any, any, any, any>> =
         : never;
 
 export type PluvServerConfig<
-    TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
+    TPlatform extends AbstractPlatform<any, any> = AbstractPlatform<any, any>,
     TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null = any,
     TContext extends Record<string, any> = {},
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
@@ -42,7 +42,7 @@ export type PluvServerConfig<
 };
 
 type BaseCreateRoomOptions<
-    TPlatform extends AbstractPlatform<any>,
+    TPlatform extends AbstractPlatform<any, any>,
     TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null,
     TContext extends Record<string, any>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>,
@@ -51,7 +51,7 @@ type BaseCreateRoomOptions<
 };
 
 export type CreateRoomOptions<
-    TPlatform extends AbstractPlatform<any>,
+    TPlatform extends AbstractPlatform<any, any>,
     TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null,
     TContext extends Record<string, any>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>,
@@ -60,7 +60,7 @@ export type CreateRoomOptions<
     : [Id<BaseCreateRoomOptions<TPlatform, TAuthorize, TContext, TEvents> & InferRoomContextType<TPlatform>>];
 
 export class PluvServer<
-    TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
+    TPlatform extends AbstractPlatform<any, any> = AbstractPlatform<any, any>,
     TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null = any,
     TContext extends Record<string, any> = {},
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
@@ -337,7 +337,7 @@ export class PluvServer<
          * to support platformPluv
          * @date December 15, 2024
          */
-        if (this._platform._createToken) return await this._platform._createToken(params);
+        if (this._platform._createToken) return await this._platform._createToken(params as any);
 
         const ioAuthorize = this._getIOAuthorize(params);
         const secret = ioAuthorize?.secret ?? null;

--- a/packages/io/src/authorize.ts
+++ b/packages/io/src/authorize.ts
@@ -15,20 +15,20 @@ export interface JWT<TUser extends BaseUser> {
     user: TUser;
 }
 
-export type JWTEncodeParams<TUser extends BaseUser | null, TPlatform extends AbstractPlatform> = {
+export type JWTEncodeParams<TUser extends BaseUser | null, TPlatform extends AbstractPlatform<any, any>> = {
     maxAge?: number;
     room: string;
     user: TUser extends BaseUser ? TUser : "Error: Cannot create token without authorization!";
 } & InferInitContextType<TPlatform>;
 
 export interface AuthorizeParams {
-    platform: AbstractPlatform;
+    platform: AbstractPlatform<any, any>;
     secret: string;
 }
 
 export interface AuthorizeModule {
     decode: <TUser extends BaseUser>(jwt: string) => Promise<TUser | null>;
-    encode: <TUser extends BaseUser, TPlatform extends AbstractPlatform>(
+    encode: <TUser extends BaseUser, TPlatform extends AbstractPlatform<any, any>>(
         params: JWTEncodeParams<TUser, TPlatform>,
     ) => Promise<string>;
 }
@@ -38,7 +38,7 @@ const now = () => (Date.now() / 1_000) | 0;
 export const authorize = (params: AuthorizeParams) => {
     const { platform, secret } = params;
 
-    const encode = async <TUser extends BaseUser, TPlatform extends AbstractPlatform>(
+    const encode = async <TUser extends BaseUser, TPlatform extends AbstractPlatform<any, any>>(
         encodeParams: JWTEncodeParams<TUser, TPlatform>,
     ): Promise<string> => {
         const { maxAge = DEFAULT_MAX_AGE_MS, room, user } = encodeParams;

--- a/packages/platform-cloudflare/src/createPluvHandler.ts
+++ b/packages/platform-cloudflare/src/createPluvHandler.ts
@@ -36,16 +36,16 @@ export interface CreatePluvHandlerResult<TEnv extends Record<string, any> = {}> 
     handler: ExportedHandler<TEnv>;
 }
 
-type InferCloudflarePluvHandlerEnv<TPluvServer extends PluvServer<CloudflarePlatform, any, any, any>> =
-    TPluvServer extends PluvServer<CloudflarePlatform<infer IEnv>, any, any, any> ? IEnv : {};
+type InferCloudflarePluvHandlerEnv<TPluvServer extends PluvServer<CloudflarePlatform<any, any>, any, any, any>> =
+    TPluvServer extends PluvServer<CloudflarePlatform<any, infer IEnv>, any, any, any> ? IEnv : {};
 
-export const createPluvHandler = <TPluvServer extends PluvServer<CloudflarePlatform, any, any, any>>(
+export const createPluvHandler = <TPluvServer extends PluvServer<CloudflarePlatform<any, any>, any, any, any>>(
     config: CreatePluvHandlerConfig<TPluvServer, Id<InferCloudflarePluvHandlerEnv<TPluvServer>>>,
 ): CreatePluvHandlerResult<Id<InferCloudflarePluvHandlerEnv<TPluvServer>>> => {
     const { authorize, binding, endpoint = "/api/pluv", modify, io } = config;
 
     const DurableObject = class extends BaseDurableObject<Id<InferCloudflarePluvHandlerEnv<TPluvServer>>> {
-        private _room: IORoom<CloudflarePlatform>;
+        private _room: IORoom<CloudflarePlatform<any, any>>;
 
         constructor(state: DurableObjectState, env: Id<InferCloudflarePluvHandlerEnv<TPluvServer>>) {
             super(state, env);

--- a/packages/platform-cloudflare/src/platformCloudflare.ts
+++ b/packages/platform-cloudflare/src/platformCloudflare.ts
@@ -1,5 +1,5 @@
 import type { CreateIOParams, InferInitContextType, PluvContext, PluvIOAuthorize } from "@pluv/io";
-import type { BaseUser, Id, Json } from "@pluv/types";
+import type { BaseUser, Id, IOAuthorize, Json } from "@pluv/types";
 import type { CloudflarePlatformConfig } from "./CloudflarePlatform";
 import { CloudflarePlatform } from "./CloudflarePlatform";
 import type { InferCallback } from "./infer";
@@ -11,13 +11,16 @@ export type PlatformCloudflareCreateIOParams<
     TUser extends BaseUser | null = null,
 > = Id<
     CloudflarePlatformConfig<TEnv, TMeta> &
-        Omit<CreateIOParams<CloudflarePlatform<TEnv, TMeta>, TContext, TUser>, "authorize" | "context" | "platform"> & {
+        Omit<
+            CreateIOParams<CloudflarePlatform<IOAuthorize<TUser, TContext>, TEnv, TMeta>, TContext, TUser>,
+            "authorize" | "context" | "platform"
+        > & {
             authorize?: PluvIOAuthorize<
-                CloudflarePlatform<TEnv, TMeta>,
+                CloudflarePlatform<IOAuthorize<TUser, TContext>, TEnv, TMeta>,
                 TUser,
-                InferInitContextType<CloudflarePlatform<TEnv, TMeta>>
+                InferInitContextType<CloudflarePlatform<IOAuthorize<TUser, TContext>, TEnv, TMeta>>
             >;
-            context?: PluvContext<CloudflarePlatform<TEnv, TMeta>, TContext>;
+            context?: PluvContext<CloudflarePlatform<IOAuthorize<TUser, TContext>, TEnv, TMeta>, TContext>;
             types?: InferCallback<TEnv, TMeta>;
         }
 >;
@@ -29,7 +32,7 @@ export const platformCloudflare = <
     TUser extends BaseUser | null = null,
 >(
     config: PlatformCloudflareCreateIOParams<TEnv, TMeta, TContext, TUser> = {},
-): CreateIOParams<CloudflarePlatform<TEnv, TMeta>, TContext, TUser> => {
+): CreateIOParams<CloudflarePlatform<IOAuthorize<TUser, TContext>, TEnv, TMeta>, TContext, TUser> => {
     const { authorize, context, crdt, debug } = config;
 
     return {
@@ -37,6 +40,6 @@ export const platformCloudflare = <
         context,
         crdt,
         debug,
-        platform: new CloudflarePlatform<TEnv, TMeta>(config),
+        platform: new CloudflarePlatform<IOAuthorize<TUser, TContext>, TEnv, TMeta>(config),
     };
 };

--- a/packages/platform-node/src/NodePlatform.ts
+++ b/packages/platform-node/src/NodePlatform.ts
@@ -7,7 +7,7 @@ import type {
     WebSocketSerializedState,
 } from "@pluv/io";
 import { AbstractPlatform } from "@pluv/io";
-import type { Json } from "@pluv/types";
+import type { IOAuthorize, Json } from "@pluv/types";
 import crypto from "node:crypto";
 import type { IncomingMessage } from "node:http";
 import { TextDecoder } from "node:util";
@@ -23,8 +23,11 @@ export type NodePlatformConfig<TMeta extends Record<string, Json>> = { mode?: We
     | { persistence: AbstractPersistence; pubSub: AbstractPubSub }
 ) & { roomContext?: NodePlatformRoomContext<TMeta> };
 
-export class NodePlatform<TMeta extends Record<string, Json> = {}> extends AbstractPlatform<
-    NodeWebSocket,
+export class NodePlatform<
+    TAuthorize extends IOAuthorize<any, any> | null = null,
+    TMeta extends Record<string, Json> = {},
+> extends AbstractPlatform<
+    NodeWebSocket<TAuthorize>,
     { req: IncomingMessage },
     NodePlatformRoomContext<TMeta>,
     {
@@ -73,17 +76,17 @@ export class NodePlatform<TMeta extends Record<string, Json> = {}> extends Abstr
         };
     }
 
-    public acceptWebSocket(webSocket: NodeWebSocket): Promise<void> {
+    public acceptWebSocket(webSocket: NodeWebSocket<TAuthorize>): Promise<void> {
         return Promise.resolve(undefined);
     }
 
-    public convertWebSocket(webSocket: WebSocket, config: ConvertWebSocketConfig): NodeWebSocket {
+    public convertWebSocket(webSocket: WebSocket, config: ConvertWebSocketConfig): NodeWebSocket<TAuthorize> {
         const { room } = config;
 
-        return new NodeWebSocket(webSocket, { persistence: this.persistence, platform: this, room });
+        return new NodeWebSocket<TAuthorize>(webSocket, { persistence: this.persistence, platform: this, room });
     }
 
-    public getLastPing(webSocket: NodeWebSocket): number | null {
+    public getLastPing(webSocket: NodeWebSocket<TAuthorize>): number | null {
         return null;
     }
 
@@ -120,7 +123,10 @@ export class NodePlatform<TMeta extends Record<string, Json> = {}> extends Abstr
         return crypto.randomUUID();
     }
 
-    public setSerializedState(webSocket: NodeWebSocket, state: WebSocketSerializedState): WebSocketSerializedState {
+    public setSerializedState(
+        webSocket: NodeWebSocket<TAuthorize>,
+        state: WebSocketSerializedState,
+    ): WebSocketSerializedState {
         webSocket.state = state;
 
         return webSocket.state;

--- a/packages/platform-node/src/createPluvHandler.ts
+++ b/packages/platform-node/src/createPluvHandler.ts
@@ -55,7 +55,7 @@ export interface CreatePluvHandlerResult {
     wsHandler: WebSocketHandler;
 }
 
-export const createPluvHandler = <TPluvServer extends PluvServer<NodePlatform, any, any, any>>(
+export const createPluvHandler = <TPluvServer extends PluvServer<NodePlatform<any>, any, any, any>>(
     config: CreatePluvHandlerConfig<TPluvServer>,
 ): CreatePluvHandlerResult => {
     const { authorize, endpoint = "/api/pluv", io, server } = config;

--- a/packages/platform-node/src/platformNode.ts
+++ b/packages/platform-node/src/platformNode.ts
@@ -1,5 +1,5 @@
 import type { CreateIOParams, InferInitContextType, PluvContext, PluvIOAuthorize } from "@pluv/io";
-import type { BaseUser, Id, Json } from "@pluv/types";
+import type { BaseUser, Id, IOAuthorize, Json } from "@pluv/types";
 import type { NodePlatformConfig } from "./NodePlatform";
 import { NodePlatform } from "./NodePlatform";
 import type { InferCallback } from "./infer";
@@ -10,9 +10,16 @@ export type PlatformNodeCreateIOParams<
     TUser extends BaseUser | null = null,
 > = Id<
     NodePlatformConfig<TMeta> &
-        Omit<CreateIOParams<NodePlatform<TMeta>, TContext, TUser>, "authorize" | "context" | "platform"> & {
-            authorize?: PluvIOAuthorize<NodePlatform<TMeta>, TUser, InferInitContextType<NodePlatform<TMeta>>>;
-            context?: PluvContext<NodePlatform<TMeta>, TContext>;
+        Omit<
+            CreateIOParams<NodePlatform<IOAuthorize<TUser, TContext>, TMeta>, TContext, TUser>,
+            "authorize" | "context" | "platform"
+        > & {
+            authorize?: PluvIOAuthorize<
+                NodePlatform<IOAuthorize<TUser, TContext>, TMeta>,
+                TUser,
+                InferInitContextType<NodePlatform<IOAuthorize<TUser, TContext>, TMeta>>
+            >;
+            context?: PluvContext<NodePlatform<IOAuthorize<TUser, TContext>, TMeta>, TContext>;
             types?: InferCallback<TMeta>;
         }
 >;
@@ -23,7 +30,7 @@ export const platformNode = <
     TUser extends BaseUser | null = null,
 >(
     config: PlatformNodeCreateIOParams<TMeta, TContext, TUser> = {},
-): CreateIOParams<NodePlatform<TMeta>, TContext, TUser> => {
+): CreateIOParams<NodePlatform<IOAuthorize<TUser, TContext>, TMeta>, TContext, TUser> => {
     const { authorize, context, crdt, debug } = config;
 
     return {
@@ -31,6 +38,6 @@ export const platformNode = <
         context,
         crdt,
         debug,
-        platform: new NodePlatform<TMeta>(config),
+        platform: new NodePlatform<IOAuthorize<TUser, TContext>, TMeta>(config),
     };
 };


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Update how session users are stored on websockets.