### PR TITLE
fix(platform-node): fix ws server type

### DIFF
--- a/.changeset/salty-heads-clap.md
+++ b/.changeset/salty-heads-clap.md
@@ -1,0 +1,5 @@
+---
+"@pluv/platform-node": patch
+---
+
+Fixed the return type of `createWsServer` from `createPluvHandler` to be `ws.WebSocketServer` instead of `ws.Server`.

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -2,6 +2,7 @@ import type { AbstractCrdtDoc, AbstractCrdtDocFactory } from "@pluv/crdt";
 import { noop } from "@pluv/crdt";
 import type {
     BaseIOEventRecord,
+    BaseUser,
     EventMessage,
     IOEventMessage,
     IOLike,
@@ -35,11 +36,9 @@ import type {
     IOUserDisconnectedEvent,
     PluvIOAuthorize,
     ResolvedPluvIOAuthorize,
-    WebSocketSerializedState,
     WebSocketSession,
     WebSocketType,
 } from "./types";
-import { BaseUser } from "@pluv/types";
 
 type BroadcastMessage<TIO extends IORoom<any, any, any, any>> =
     | InferEventMessage<InferIOInput<TIO>>

--- a/packages/io/src/types.ts
+++ b/packages/io/src/types.ts
@@ -23,14 +23,6 @@ import type {
 import type { AbstractWebSocket } from "./AbstractWebSocket";
 import type { PluvRouter, PluvRouterEventConfig } from "./PluvRouter";
 
-declare global {
-    // eslint-disable-next-line no-var
-    var console: {
-        error: (...data: any[]) => void;
-        log: (...data: any[]) => void;
-    };
-}
-
 export type PluvContext<TPlatform extends AbstractPlatform, TContext extends Record<string, any>> =
     | TContext
     | ((params: InferRoomContextType<TPlatform>) => TContext);

--- a/packages/io/tsconfig.json
+++ b/packages/io/tsconfig.json
@@ -1,5 +1,9 @@
 {
 	"extends": "@pluv/tsconfig/library.json",
 	"include": ["next-env.d.ts", "src/*.ts"],
-	"exclude": ["node_modules"]
+	"exclude": ["node_modules"],
+	"compilerOptions": {
+		"lib": ["esnext", "dom"],
+		"types": [],
+	}
 }

--- a/packages/platform-node/src/createPluvHandler.ts
+++ b/packages/platform-node/src/createPluvHandler.ts
@@ -4,7 +4,7 @@ import type { Server as HttpServer, IncomingMessage, ServerResponse } from "node
 import Url from "node:url";
 import { match } from "path-to-regexp";
 import type { WebSocket } from "ws";
-import { Server as WsServer } from "ws";
+import { WebSocketServer } from "ws";
 import { NodePlatform } from "./NodePlatform";
 
 export type AuthorizeFunctionContext<TPluvServer extends PluvServer<any, any, any, any>> = {
@@ -50,7 +50,7 @@ export interface WebSocketHandlerResult {
 export type WebSocketHandler = (ws: WebSocket, req: IncomingMessage) => Promise<WebSocketHandlerResult>;
 
 export interface CreatePluvHandlerResult {
-    createWsServer: () => WsServer;
+    createWsServer: () => WebSocketServer;
     handler: RequestHandler;
     wsHandler: WebSocketHandler;
 }
@@ -64,7 +64,7 @@ export const createPluvHandler = <TPluvServer extends PluvServer<NodePlatform<an
         throw new Error("Cannot use createPluvHandler in detached mode for Node.js");
     }
 
-    const wsServer = new WsServer({ server });
+    const wsServer = new WebSocketServer({ server });
     const rooms = new Map<string, ReturnType<typeof io.createRoom>>();
 
     const getRoom = (roomId: string): ReturnType<typeof io.createRoom> => {

--- a/packages/tsconfig/library.json
+++ b/packages/tsconfig/library.json
@@ -6,7 +6,8 @@
 		"lib": ["esnext"],
 		"module": "esnext",
 		"target": "es6",
-		"isolatedModules": true
+		"isolatedModules": true,
+		"moduleResolution": "bundler"
 	},
 	"include": ["src"],
 	"exclude": ["node_modules"]


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fixed the return type of `createWsServer` from `createPluvHandler` to be `ws.WebSocketServer` instead of `ws.Server`.