### PR TITLE
feat(io): limit create token size to 512 bytes

### DIFF
--- a/.changeset/bumpy-walls-stop.md
+++ b/.changeset/bumpy-walls-stop.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": minor
+---
+
+**BREAKING** The `user` that is provided to `PluvServer.createToken` is now limited to be at most 512 bytes. If the `user` is any larger, `PluvServer.createToken` will now throw an error.

--- a/packages/io/src/constants.ts
+++ b/packages/io/src/constants.ts
@@ -1,1 +1,2 @@
+export const MAX_USER_SIZE_BYTES = 512;
 export const PING_TIMEOUT_MS = 30_000;


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Added a 512 byte limit to `user` provided to `PluvServer.createToken`.
