### PR TITLE
feat(io): limit presence max size to 512 bytes

### DIFF
--- a/.changeset/clever-ghosts-say.md
+++ b/.changeset/clever-ghosts-say.md
@@ -2,4 +2,4 @@
 "@pluv/io": minor
 ---
 
-**BREAKING** Updated the way `user` is stored and read from the websocket, so now `user` is persisted in-memory rather than from persistent storage (improves performance and lowers cost in some cases). This change primarily affects pluv platforms, which are intended for internal use only, and therefore should not be mostly non-breaking.
+**BREAKING** Updated the way `user` is stored and read from the websocket, so now `user` is persisted in-memory rather than from persistent storage (improves performance and lowers cost in some cases). This change primarily affects pluv platforms, which are intended for internal use only, and therefore should be mostly non-breaking.

--- a/.changeset/empty-banks-judge.md
+++ b/.changeset/empty-banks-judge.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": minor
+---
+
+**BREAKING** User's presence is now limited to be at most 512 bytes. If the presence is any larger, the `PluvServer` will now throw an error.

--- a/packages/io/src/PluvServer.ts
+++ b/packages/io/src/PluvServer.ts
@@ -10,7 +10,7 @@ import type { PluvRouterEventConfig } from "./PluvRouter";
 import { PluvRouter } from "./PluvRouter";
 import type { JWTEncodeParams } from "./authorize";
 import { authorize } from "./authorize";
-import { MAX_USER_SIZE_BYTES, PING_TIMEOUT_MS } from "./constants";
+import { MAX_PRESENCE_SIZE_BYTES, MAX_USER_SIZE_BYTES, PING_TIMEOUT_MS } from "./constants";
 import type {
     BasePluvIOListeners,
     GetInitialStorageFn,
@@ -171,6 +171,13 @@ export class PluvServer<
             if (!session) return {};
 
             const updated = Object.assign(Object.create(null), session.presence, presence);
+            const bytes = new TextEncoder().encode(JSON.stringify(updated)).length;
+
+            if (bytes > MAX_PRESENCE_SIZE_BYTES) {
+                throw new Error(
+                    `Large presence. Presence must be at most 512 bytes. Current size: ${bytes.toLocaleString()}`,
+                );
+            }
 
             context.presence = updated;
 

--- a/packages/io/src/constants.ts
+++ b/packages/io/src/constants.ts
@@ -1,2 +1,3 @@
+export const MAX_PRESENCE_SIZE_BYTES = 512;
 export const MAX_USER_SIZE_BYTES = 512;
 export const PING_TIMEOUT_MS = 30_000;


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Limit user's presence max size to 512 bytes.