### PR TITLE
feat(io): emit sync state when garbage collected

### DIFF
--- a/.changeset/tiny-moles-worry.md
+++ b/.changeset/tiny-moles-worry.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": patch
+---
+
+Each time garbage collection is run, a sync-stage event will be emitted to connected sessions with info of currently connected users.

--- a/packages/types/src/pluv.ts
+++ b/packages/types/src/pluv.ts
@@ -57,6 +57,9 @@ export type BaseIOEventRecord<TAuthorize extends IOAuthorize<any, any>> = {
     $storageUpdated: {
         state: string;
     };
+    $syncStateReceived: {
+        userIds: readonly string[];
+    };
     $userJoined: {
         connectionId: string;
         presence: JsonObject;


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Emit a sync-state of currently connected users when garbage collection is run.