### PR TITLE
chore: deprecate create pluv handler

### DIFF
--- a/.changeset/big-tables-occur.md
+++ b/.changeset/big-tables-occur.md
@@ -1,0 +1,6 @@
+---
+"@pluv/platform-cloudflare": patch
+"@pluv/platform-node": patch
+---
+
+Deprecated `createPluvHandler`. Instead, documentation will be provided on how to host pluv.io yourself on Node.js and Cloudflare Workers.

--- a/packages/platform-cloudflare/src/createPluvHandler.ts
+++ b/packages/platform-cloudflare/src/createPluvHandler.ts
@@ -40,6 +40,10 @@ export interface CreatePluvHandlerResult<TEnv extends Record<string, any> = {}> 
 type InferCloudflarePluvHandlerEnv<TPluvServer extends PluvServer<CloudflarePlatform<any, any>, any, any, any>> =
     TPluvServer extends PluvServer<CloudflarePlatform<any, infer IEnv>, any, any, any> ? IEnv : {};
 
+/**
+ * @deprecated Instructions will be provided on https://pluv.io on how to host this yourself instead.
+ * @date April 27, 2025
+ */
 export const createPluvHandler = <TPluvServer extends PluvServer<CloudflarePlatform<any, any>, any, any, any>>(
     config: CreatePluvHandlerConfig<TPluvServer, Id<InferCloudflarePluvHandlerEnv<TPluvServer>>>,
 ): CreatePluvHandlerResult<Id<InferCloudflarePluvHandlerEnv<TPluvServer>>> => {

--- a/packages/platform-node/src/createPluvHandler.ts
+++ b/packages/platform-node/src/createPluvHandler.ts
@@ -55,6 +55,10 @@ export interface CreatePluvHandlerResult {
     wsHandler: WebSocketHandler;
 }
 
+/**
+ * @deprecated Instructions will be provided on https://pluv.io on how to host this yourself instead.
+ * @date April 27, 2025
+ */
 export const createPluvHandler = <TPluvServer extends PluvServer<NodePlatform<any>, any, any, any>>(
     config: CreatePluvHandlerConfig<TPluvServer>,
 ): CreatePluvHandlerResult => {


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Deprecated `createPluvHandler`.