### PR TITLE
fix(io): fix io authorize override

### DIFF
--- a/.changeset/odd-cameras-care.md
+++ b/.changeset/odd-cameras-care.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": patch
+---
+
+Fixed not applying user size limits when calling `PluvIO.authorize` and not allowing it to be overwritten for `platformPluv`.


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fixed not applying user size limits when calling `PluvIO.authorize` and not allowing it to be overwritten for `platformPluv`.