### PR TITLE
fix(io): allow smaller room names

### DIFF
--- a/.changeset/eager-rivers-obey.md
+++ b/.changeset/eager-rivers-obey.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": patch
+---
+
+Fix 1 and 2 character long room names not being supported.

--- a/packages/io/src/PluvServer.ts
+++ b/packages/io/src/PluvServer.ts
@@ -320,7 +320,7 @@ export class PluvServer<
             throw new Error(`\`createRoom\` is unsupported for \`${this._platform._name}\``);
         }
 
-        if (!/^[a-z0-9]+[a-z0-9\-_]+[a-z0-9]+$/i.test(room)) throw new Error("Unsupported room name");
+        if (!/^[a-z0-9](?:[a-z0-9-_]*[a-z0-9])?$/i.test(room)) throw new Error("Unsupported room name");
 
         const roomContext = platformRoomContext as InferRoomContextType<TPlatform>;
         const context: TContext = typeof this._context === "function" ? this._context(roomContext) : this._context;


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fix 1 and 2 character long room names not being supported.