### PR TITLE
fix(client): fix reconnect metadata

### DIFF
--- a/.changeset/wicked-regions-roll.md
+++ b/.changeset/wicked-regions-roll.md
@@ -1,0 +1,5 @@
+---
+"@pluv/client": patch
+---
+
+Fix `PluvRoom._reconnect` not being called with the last used metadata (from `PluvRoom.connect`).

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -1371,7 +1371,11 @@ export class PluvRoom<
     }
 
     private _setMetadata(metadata: TMetadata): TMetadata {
-        return this.metadata ? this.metadata.parse(metadata) : metadata;
+        const parsed = this.metadata ? this.metadata.parse(metadata) : metadata;
+
+        this._lastMetadata = parsed;
+
+        return parsed;
     }
 
     private _updateState(updater: (oldState: WebSocketState<TIO>) => WebSocketState<TIO>): WebSocketState<TIO> {


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fix `PluvRoom._reconnect` not being called with the last used metadata (from `PluvRoom.connect`).