### PR TITLE
feat(react): initial storage builder

### DIFF
--- a/.changeset/full-pants-kneel.md
+++ b/.changeset/full-pants-kneel.md
@@ -1,0 +1,44 @@
+---
+"@pluv/react": minor
+---
+
+**Deprecated** Declaring top-level types on your CRDT storage via the `yjs` or `loro` utility (e.g. `yjs.array` or `loro.list`) for the `initialStorage` prop on `PluvRoomProvider` is now deprecated, to be removed in the next major release (v2). Continuing to use the `yjs` or `loro` utilities to declare top-level types will log a warning to your console while in development mode (i.e. when `process.env.NODE_ENV === "development"`). To declare top-level types, you should now use the builder type exposed in the `initialStorage` function. See the example below:
+
+```tsx
+import { yjs } from "@pluv/crdt-yjs";
+
+// Before
+<PluvRoomProvider
+    room="example-room"
+    initialStorage={() => ({
+        // Using the `yjs` or `loro` utility (in this case `yjs.map`) when
+        // declaring top-level types is now deprecated
+        topType: yjs.map([
+            ["key1", yjs.text("")],
+            ["key2", yjs.text("")],
+        ]),
+    })}
+>
+    <div />
+</PluvRoomProvider>
+
+// After
+<PluvRoomProvider
+    room="example-room"
+    initialStorage={(t) => ({
+        // Top-level properties must now use the builder (in this case `t`).
+        // This effectively calls `yjs.getMap("topType")` to instantiate the type on
+        // the root document.
+        // This simply returns the native Yjs shared-types (e.g. Y.Map), which
+        // allows you operate on your yjs shared-typess in a more native way.
+        topType: t.map("topType", [
+            ["key1", yjs.text("")],
+            ["key2", yjs.text("")],
+        ]),
+    })}
+>
+    <div />
+</PluvRoomProvider>
+```
+
+The functions on the builder type calls the native yjs shared-type (or loro container type) instantiating methods and returns the native types (e.g. `t.map("topType")` is simply just a `Y.Doc.getMap("topType")`) call under the hood. This allows you to declare your type in a more yjs-native and predictable way, and enables declaring more complex initial storage states if needed.

--- a/.changeset/full-pants-kneel.md
+++ b/.changeset/full-pants-kneel.md
@@ -32,6 +32,8 @@ import { yjs } from "@pluv/crdt-yjs";
         // This simply returns the native Yjs shared-types (e.g. Y.Map), which
         // allows you operate on your yjs shared-typess in a more native way.
         topType: t.map("topType", [
+            // Declaring nested types should continue to use the `yjs` utilities
+            // you've used before
             ["key1", yjs.text("")],
             ["key2", yjs.text("")],
         ]),

--- a/packages/addon-indexeddb/src/addonIndexedDB.ts
+++ b/packages/addon-indexeddb/src/addonIndexedDB.ts
@@ -1,25 +1,25 @@
 import type { PluvRoom, PluvRoomAddon } from "@pluv/client";
-import type { CrdtType } from "@pluv/crdt";
+import type { AbstractCrdtDocFactory, CrdtType } from "@pluv/crdt";
 import type { IOLike, JsonObject } from "@pluv/types";
 import { IndexedDBStorage } from "./IndexedDBStorage";
 
 export interface AddonIndexedDBConfig<
     TIO extends IOLike<any, any>,
-    TMetadata extends JsonObject = {},
-    TPresence extends JsonObject = {},
-    TStorage extends Record<string, CrdtType<any, any>> = {},
+    TMetadata extends JsonObject,
+    TPresence extends JsonObject,
+    TCrdt extends AbstractCrdtDocFactory<any>,
 > {
-    enabled?: boolean | ((room: PluvRoom<TIO, TMetadata, TPresence, TStorage>) => boolean);
+    enabled?: boolean | ((room: PluvRoom<TIO, TMetadata, TPresence, TCrdt>) => boolean);
 }
 
 export const addonIndexedDB = <
     TIO extends IOLike<any, any>,
-    TMetadata extends JsonObject = {},
-    TPresence extends JsonObject = {},
-    TStorage extends Record<string, CrdtType<any, any>> = {},
+    TMetadata extends JsonObject,
+    TPresence extends JsonObject,
+    TCrdt extends AbstractCrdtDocFactory<any>,
 >(
-    config?: AddonIndexedDBConfig<TIO, TMetadata, TPresence, TStorage>,
-): PluvRoomAddon<TIO, TMetadata, TPresence, TStorage> => {
+    config?: AddonIndexedDBConfig<TIO, TMetadata, TPresence, TCrdt>,
+): PluvRoomAddon<TIO, TMetadata, TPresence, TCrdt> => {
     const { enabled = true } = config ?? {};
 
     return ({ room }) => {

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -1,4 +1,4 @@
-import type { CrdtType } from "@pluv/crdt";
+import type { AbstractCrdtDocFactory, NoopCrdtDocFactory } from "@pluv/crdt";
 import type { IOLike, JsonObject } from "@pluv/types";
 import type { PluvClientOptions } from "./PluvClient";
 import { PluvClient } from "./PluvClient";
@@ -6,10 +6,10 @@ import { PluvClient } from "./PluvClient";
 export const createClient = <
     TIO extends IOLike<any, any>,
     TPresence extends JsonObject = {},
-    TStorage extends Record<string, CrdtType<any, any>> = {},
+    TCrdt extends AbstractCrdtDocFactory<any> = NoopCrdtDocFactory,
     TMetadata extends JsonObject = {},
 >(
-    options: PluvClientOptions<TIO, TPresence, TStorage, TMetadata>,
-): PluvClient<TIO, TPresence, TStorage, TMetadata> => {
-    return new PluvClient<TIO, TPresence, TStorage, TMetadata>(options);
+    options: PluvClientOptions<TIO, TPresence, TCrdt, TMetadata>,
+): PluvClient<TIO, TPresence, TCrdt, TMetadata> => {
+    return new PluvClient<TIO, TPresence, TCrdt, TMetadata>(options);
 };

--- a/packages/crdt-loro/src/doc/CrdtLoroDocFactory.ts
+++ b/packages/crdt-loro/src/doc/CrdtLoroDocFactory.ts
@@ -6,10 +6,10 @@ import type { LoroBuilder } from "./builder";
 export class CrdtLoroDocFactory<
     TStorage extends Record<string, LoroType<any, any>>,
 > extends AbstractCrdtDocFactory<TStorage> {
-    private _initialStorage: (builder: LoroBuilder) => TStorage;
+    public readonly _initialStorage: (builder: LoroBuilder) => TStorage;
 
     constructor(initialStorage: (builder: LoroBuilder) => TStorage = () => ({}) as TStorage) {
-        super();
+        super(initialStorage);
 
         this._initialStorage = initialStorage;
     }

--- a/packages/crdt-yjs/src/doc/CrdtYjsDocFactory.ts
+++ b/packages/crdt-yjs/src/doc/CrdtYjsDocFactory.ts
@@ -4,12 +4,12 @@ import { CrdtYjsDoc } from "./CrdtYjsDoc";
 import type { YjsBuilder } from "./builder";
 
 export class CrdtYjsDocFactory<
-    TStorage extends Record<string, YjsType<any, any>>,
+    TStorage extends Record<string, YjsType<any, any>> = {},
 > extends AbstractCrdtDocFactory<TStorage> {
-    private _initialStorage: (builder: YjsBuilder) => TStorage;
+    public readonly _initialStorage: (builder: YjsBuilder) => TStorage;
 
     constructor(initialStorage: (builder: YjsBuilder) => TStorage = () => ({}) as TStorage) {
-        super();
+        super(initialStorage);
 
         this._initialStorage = initialStorage;
     }
@@ -19,7 +19,7 @@ export class CrdtYjsDocFactory<
     }
 
     public getFactory(
-        initialStorage?: ((builder: YjsBuilder) => TStorage) | undefined,
+        initialStorage: (builder: YjsBuilder) => TStorage,
     ): CrdtYjsDocFactory<TStorage> {
         return new CrdtYjsDocFactory<TStorage>(initialStorage ?? this._initialStorage);
     }

--- a/packages/crdt/src/AbstractCrdtDocFactory.ts
+++ b/packages/crdt/src/AbstractCrdtDocFactory.ts
@@ -2,6 +2,12 @@ import type { CrdtDocLike } from "@pluv/types";
 import type { CrdtType } from "./types";
 
 export abstract class AbstractCrdtDocFactory<TStorage extends Record<string, CrdtType<any, any>>> {
+    public _initialStorage: (builder: any) => TStorage;
+
+    constructor(initialStorage: (builder: any) => TStorage) {
+        this._initialStorage = initialStorage;
+    }
+
     public abstract getEmpty(): CrdtDocLike<TStorage>;
     public abstract getFactory(
         initialStorage?: (builder: any) => TStorage,

--- a/packages/crdt/src/NoopCrdtDocFactory.ts
+++ b/packages/crdt/src/NoopCrdtDocFactory.ts
@@ -2,6 +2,10 @@ import { AbstractCrdtDocFactory } from "./AbstractCrdtDocFactory";
 import { NoopCrdtDoc } from "./NoopCrdtDoc";
 
 export class NoopCrdtDocFactory extends AbstractCrdtDocFactory<any> {
+    constructor(initialStorage: () => {} = () => ({})) {
+        super(initialStorage);
+    }
+
     public getEmpty(): NoopCrdtDoc {
         return new NoopCrdtDoc();
     }

--- a/packages/crdt/src/index.ts
+++ b/packages/crdt/src/index.ts
@@ -8,4 +8,10 @@ export { AbstractCrdtDocFactory } from "./AbstractCrdtDocFactory";
 export { noop } from "./noop";
 export { NoopCrdtDoc } from "./NoopCrdtDoc";
 export { NoopCrdtDocFactory } from "./NoopCrdtDocFactory";
-export type { CrdtType, InferCrdtJson } from "./types";
+export type {
+    CrdtType,
+    InferBuilder,
+    InferCrdtJson,
+    InferInitialStorageFn,
+    InferStorage,
+} from "./types";

--- a/packages/crdt/src/types.ts
+++ b/packages/crdt/src/types.ts
@@ -1,4 +1,5 @@
 import type { Json } from "@pluv/types";
+import { AbstractCrdtDocFactory } from "./AbstractCrdtDocFactory";
 
 export type CrdtType<TValue extends unknown, TJson extends unknown = any> = Omit<
     TValue,
@@ -19,3 +20,14 @@ export type InferCrdtJson<T extends unknown> =
               : T extends Json
                 ? T
                 : string;
+
+export type InferInitialStorageFn<TFactory extends AbstractCrdtDocFactory<any>> =
+    TFactory["_initialStorage"];
+
+export type InferStorage<TFactory extends AbstractCrdtDocFactory<any>> = ReturnType<
+    InferInitialStorageFn<TFactory>
+>;
+
+export type InferBuilder<TFactory extends AbstractCrdtDocFactory<any>> = Parameters<
+    InferInitialStorageFn<TFactory>
+>[0];

--- a/packages/types/src/pluv/crdt.ts
+++ b/packages/types/src/pluv/crdt.ts
@@ -30,8 +30,8 @@ export interface DocBatchApplyEncodedStateParams {
     updates?: Maybe<readonly Maybe<string | Uint8Array>[]>;
 }
 
-export interface DocSubscribeCallbackParams<T extends Record<string, CrdtType<any, any>>> {
-    doc: CrdtDocLike<T>;
+export interface DocSubscribeCallbackParams<TStorage extends Record<string, CrdtType<any, any>>> {
+    doc: CrdtDocLike<TStorage>;
     local: boolean;
     origin?: string | null;
     update: string;

--- a/tests/types/package.json
+++ b/tests/types/package.json
@@ -5,7 +5,7 @@
     "sideEffects": false,
     "private": true,
     "scripts": {
-        "test": "tsc"
+        "test": "tsc --noEmit"
     },
     "dependencies": {
         "@pluv/addon-indexeddb": "workspace:^",

--- a/tests/types/src/types.test.tsx
+++ b/tests/types/src/types.test.tsx
@@ -1,9 +1,12 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { infer as clientInfer, createClient } from "@pluv/client";
+import { yjs } from "@pluv/crdt-yjs";
 import { createIO } from "@pluv/io";
 import { platformCloudflare } from "@pluv/platform-cloudflare";
+import { createBundle } from "@pluv/react";
 import { z } from "@zod/mini";
 import { expectTypeOf } from "expect-type";
+import type { Array as YArray } from "yjs";
 
 const io = createIO(
     platformCloudflare({
@@ -43,10 +46,17 @@ const ioServer = io.server({
 const types = clientInfer((i) => ({ io: i<typeof ioServer> }));
 const client = createClient({
     authEndpoint: () => "",
+    initialStorage: yjs.doc((t) => ({
+        messages: t.array<string>("messages"),
+    })),
     types,
 });
 
-const room = client.createRoom("test-room");
+const room = client.createRoom("test-room", {
+    initialStorage: yjs.doc((t) => ({
+        messages: t.array("messages"),
+    })),
+});
 
 room.event.receiveMessage((params) => {
     expectTypeOf<(typeof params)["data"]>().toEqualTypeOf<{ message: string }>();
@@ -54,3 +64,33 @@ room.event.receiveMessage((params) => {
     // @ts-expect-error
     expectTypeOf<(typeof params)["data"]>().toEqualTypeOf<{}>();
 });
+
+room.storage("messages", (messages) => {
+    expectTypeOf<typeof messages>().toEqualTypeOf<string[]>();
+});
+
+const { PluvRoomProvider, useStorage } = createBundle(client);
+
+<PluvRoomProvider
+    initialStorage={(t) => ({
+        messages: t.array("messages"),
+    })}
+    room="test-room"
+>
+    <div />
+</PluvRoomProvider>;
+
+<PluvRoomProvider
+    // @ts-expect-error
+    initialStorage={(t) => ({
+        invalidKey: t.array("invalidKey"),
+    })}
+    room="test-room"
+>
+    <div />
+</PluvRoomProvider>;
+
+const storageMessages = useStorage("messages");
+
+expectTypeOf(storageMessages[0]).toEqualTypeOf<string[] | null>();
+expectTypeOf(storageMessages[1]).toEqualTypeOf<yjs.YjsType<YArray<string>, string[]> | null>();

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -1,10 +1,12 @@
 {
 	"extends": "@pluv/tsconfig/library.json",
-	"include": ["src/**/*.test.ts"],
+	"include": ["src/**/*.test.ts", "src/**/*.test.tsx"],
 	"exclude": ["node_modules"],
 	"compilerOptions": {
+		"lib": ["dom", "esnext"],
 		"noEmit": true,
 		"strict": true,
+		"jsx": "react-jsx",
 		"types": ["@cloudflare/workers-types"]
 	}
 }


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] I have added or updated the tests related to the changes made.

---

## Changelog

Updated the `initialStorage` prop on `PluvRoomProvider` to now require using the builder type to declare type-level types. Deprecated using the crdt utilities to declare top-level types.