### PR TITLE
fix(client): fix ignored create room initial storage

### DIFF
--- a/.changeset/some-dolls-yell.md
+++ b/.changeset/some-dolls-yell.md
@@ -1,0 +1,5 @@
+---
+"@pluv/client": patch
+---
+
+Fixed `initialStorage` on `PluvClient.createRoom` not overwriting the `initialStorage` from the `PluvClient` constructor.

--- a/packages/client/src/PluvClient.ts
+++ b/packages/client/src/PluvClient.ts
@@ -130,7 +130,7 @@ export class PluvClient<
             authEndpoint: this._authEndpoint,
             debug: options.debug,
             initialPresence: options.initialPresence,
-            initialStorage: this._initialStorage,
+            initialStorage: options.initialStorage ?? this._initialStorage,
             limits: this._limits,
             metadata: this.metadata,
             onAuthorizationFail: options.onAuthorizationFail,


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fixed ignored `PluvClient.createRoom` `initialStorage` option.