### PR TITLE
feat(client): deprecate several moved subscriptions

### DIFF
--- a/.changeset/five-tables-brush.md
+++ b/.changeset/five-tables-brush.md
@@ -1,0 +1,21 @@
+---
+"@pluv/client": minor
+---
+
+**DEPRECATED** `PluvRoom.event`, `PluvRoom.storage`, `PluvRoom.storageRoot` and `PluvRoom.other` have all been deprecated, to be removed in v3. These now exist under `PluvRoom.subscribe` instead.
+
+```ts
+const room = client.createRoom("example-room");
+
+// Before (now deprecated)
+room.event.receiveMessage((event) => {});
+room.storage.messages((messages) => {});
+room.storageRoot((storage) => {});
+room.other(("id_...", other) => {});
+
+// After
+room.subscribe.event.receiveMessage((event) => {});
+room.subscribe.storage.messages((messages) => {});
+room.subscribe.storageRoot((storage) => {});
+room.subscribe.other(("id_...", other) => {});
+```

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -470,6 +470,9 @@ export class PluvRoom<
         this._stateNotifier.subjects["my-presence"].next(null);
     }
 
+    /**
+     * @deprecated Use PluvRoom.subscribe.event instead
+     */
     public event = new Proxy(
         <TEvent extends keyof InferIOOutput<MergeEvents<TEvents, TIO>>>(
             event: TEvent,
@@ -535,6 +538,9 @@ export class PluvRoom<
         return this._crdtManager.doc.toJson(type);
     }
 
+    /**
+     * @deprecated Use PluvRoom.storage.other instead
+     */
     public other = (
         connectionId: string,
         callback: OtherSubscriptionCallback<TIO, TPresence>,
@@ -550,6 +556,9 @@ export class PluvRoom<
         this._crdtManager.doc.redo();
     };
 
+    /**
+     * @deprecated Use PluvRoom.subscribe.storage instead
+     */
     public storage = new Proxy(
         <TKey extends keyof InferStorage<TCrdt>>(
             key: TKey,
@@ -572,6 +581,10 @@ export class PluvRoom<
         },
     ) as StorageProxy<InferStorage<TCrdt>>;
 
+    /**
+     * @deprecated Use PluvRoom.subscribe.storage instead
+     * @description Subscribes to the root storage object (serialized)
+     */
     public storageRoot = (
         callback: (value: {
             [P in keyof InferStorage<TCrdt>]: InferCrdtJson<InferStorage<TCrdt>[P]>;

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -539,7 +539,7 @@ export class PluvRoom<
     }
 
     /**
-     * @deprecated Use PluvRoom.storage.other instead
+     * @deprecated Use PluvRoom.subscribe.other instead
      */
     public other = (
         connectionId: string,

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -471,7 +471,7 @@ export class PluvRoom<
     }
 
     /**
-     * @deprecated Use PluvRoom.subscribe.event instead
+     * @deprecated To be removed in v3. Use PluvRoom.subscribe.event instead
      */
     public event = new Proxy(
         <TEvent extends keyof InferIOOutput<MergeEvents<TEvents, TIO>>>(
@@ -539,7 +539,7 @@ export class PluvRoom<
     }
 
     /**
-     * @deprecated Use PluvRoom.subscribe.other instead
+     * @deprecated To be removed in v3. Use PluvRoom.subscribe.other instead
      */
     public other = (
         connectionId: string,
@@ -557,7 +557,7 @@ export class PluvRoom<
     };
 
     /**
-     * @deprecated Use PluvRoom.subscribe.storage instead
+     * @deprecated To be removed in v3. To be removed in v3. Use PluvRoom.subscribe.storage instead
      */
     public storage = new Proxy(
         <TKey extends keyof InferStorage<TCrdt>>(
@@ -582,7 +582,7 @@ export class PluvRoom<
     ) as StorageProxy<InferStorage<TCrdt>>;
 
     /**
-     * @deprecated Use PluvRoom.subscribe.storage instead
+     * @deprecated To be removed in v3. Use PluvRoom.subscribe.storage instead
      * @description Subscribes to the root storage object (serialized)
      */
     public storageRoot = (


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

**DEPRECATED** `PluvRoom.event`, `PluvRoom.storage`, `PluvRoom.storageRoot` and `PluvRoom.other` have all been deprecated, to be removed in v3. These now exist under `PluvRoom.subscribe` instead.
