### PR TITLE
feat(client): getStorageLoaded

### DIFF
--- a/.changeset/rude-insects-sort.md
+++ b/.changeset/rude-insects-sort.md
@@ -1,0 +1,11 @@
+---
+"@pluv/client": minor
+---
+
+**DEPRECATED** `PluvRoom.storageLoaded` will be removed in v3. Added `PluvRoom.getStorageLoaded` with improved detection of when the storage was synced.
+
+```ts
+const room = client.createRoom("example-room");
+
+room.getStorageLoaded
+```

--- a/packages/client/src/MockedRoom.ts
+++ b/packages/client/src/MockedRoom.ts
@@ -21,6 +21,7 @@ import type {
     SubscriptionCallback,
     UpdateMyPresenceAction,
     UserInfo,
+    WebSocketConnection,
     WebSocketState,
 } from "@pluv/types";
 import { ConnectionState, StorageState } from "@pluv/types";
@@ -41,7 +42,6 @@ import type {
     EventResolverContext,
     InternalSubscriptions,
     PluvClientLimits,
-    WebSocketConnection,
 } from "./types";
 
 export type MockedRoomEvents<TIO extends IOLike> = Partial<{

--- a/packages/client/src/MockedRoom.ts
+++ b/packages/client/src/MockedRoom.ts
@@ -23,7 +23,7 @@ import type {
     UserInfo,
     WebSocketState,
 } from "@pluv/types";
-import { ConnectionState } from "@pluv/types";
+import { ConnectionState, StorageState } from "@pluv/types";
 import type { CrdtManagerOptions } from "./CrdtManager";
 import { CrdtManager } from "./CrdtManager";
 import { CrdtNotifier } from "./CrdtNotifier";
@@ -83,9 +83,11 @@ export class MockedRoom<
         },
         connection: {
             attempts: 0,
-            count: 1,
             id: null,
             state: ConnectionState.Untouched,
+        },
+        storage: {
+            state: StorageState.Unavailable,
         },
         webSocket: null,
     };
@@ -119,10 +121,6 @@ export class MockedRoom<
         });
 
         this._observeCrdt();
-    }
-
-    public get storageLoaded(): boolean {
-        return true;
     }
 
     public broadcast = new Proxy(
@@ -249,10 +247,13 @@ export class MockedRoom<
     ): InferCrdtJson<InferStorage<TCrdt>[TKey]> | null;
     public getStorageJson<TKey extends keyof InferStorage<TCrdt>>(type?: TKey) {
         if (this._state.connection.id === null) return null;
-
         if (typeof type === "undefined") return this._crdtManager.doc.toJson();
 
         return this._crdtManager.doc.toJson(type);
+    }
+
+    public getStorageLoaded(): boolean {
+        return true;
     }
 
     public other = (

--- a/packages/client/src/MockedRoom.ts
+++ b/packages/client/src/MockedRoom.ts
@@ -69,6 +69,11 @@ export class MockedRoom<
 {
     public readonly id: string;
 
+    /**
+     * @deprecated To be removed in v3. Use `getStorageLoaded` instead.
+     */
+    public readonly storageLoaded: boolean = true;
+
     private readonly _crdtManager: CrdtManager<TCrdt>;
     private readonly _crdtNotifier = new CrdtNotifier<InferStorage<TCrdt>>();
     private readonly _eventNotifier = new EventNotifier<MergeEvents<TEvents, TIO>>();

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -34,6 +34,7 @@ import type {
     SubscriptionCallback,
     UpdateMyPresenceAction,
     UserInfo,
+    WebSocketConnection,
     WebSocketState,
 } from "@pluv/types";
 import { ConnectionState, StorageState } from "@pluv/types";
@@ -54,7 +55,6 @@ import type {
     InternalSubscriptions,
     PluvClientLimits,
     PublicKey,
-    WebSocketConnection,
     WithMetadata,
 } from "./types";
 import type { UsersManagerConfig } from "./UsersManager";

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -306,13 +306,6 @@ export class PluvRoom<
         this._crdtManager = new CrdtManager<TCrdt>({ initialStorage });
     }
 
-    public get storageLoaded(): boolean {
-        return (
-            this._state.storage.state === StorageState.Offline ||
-            this._state.storage.state === StorageState.Synced
-        );
-    }
-
     public get webSocket(): WebSocket | null {
         return this._state.webSocket;
     }
@@ -538,7 +531,6 @@ export class PluvRoom<
     ): InferCrdtJson<InferStorage<TCrdt>[TKey]> | null;
     public getStorageJson<TKey extends keyof InferStorage<TCrdt>>(type?: TKey) {
         if (this._state.connection.id === null) return null;
-
         if (typeof type === "undefined") return this._crdtManager.doc.toJson();
 
         const sharedType = this._crdtManager.get(type);
@@ -547,6 +539,13 @@ export class PluvRoom<
 
         return this._crdtManager.doc.toJson(type);
     }
+
+    public getStorageLoaded = (): boolean => {
+        return (
+            this._state.storage.state === StorageState.Offline ||
+            this._state.storage.state === StorageState.Synced
+        );
+    };
 
     /**
      * @deprecated To be removed in v3. Use PluvRoom.subscribe.other instead

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -306,6 +306,13 @@ export class PluvRoom<
         this._crdtManager = new CrdtManager<TCrdt>({ initialStorage });
     }
 
+    /**
+     * @deprecated To be removed in v3. Use `getStorageLoaded` instead.
+     */
+    public get storageLoaded(): boolean {
+        return this.getStorageLoaded();
+    }
+
     public get webSocket(): WebSocket | null {
         return this._state.webSocket;
     }

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -36,7 +36,7 @@ import type {
     UserInfo,
     WebSocketState,
 } from "@pluv/types";
-import { ConnectionState } from "@pluv/types";
+import { ConnectionState, StorageState } from "@pluv/types";
 import type { AbstractStorageStore } from "./AbstractStorageStore";
 import type { CrdtManagerOptions } from "./CrdtManager";
 import { CrdtManager } from "./CrdtManager";
@@ -244,9 +244,11 @@ export class PluvRoom<
         },
         connection: {
             attempts: 0,
-            count: 0,
             id: null,
             state: ConnectionState.Untouched,
+        },
+        storage: {
+            state: StorageState.Unavailable,
         },
         webSocket: null,
     };
@@ -436,6 +438,7 @@ export class PluvRoom<
         this._updateState((oldState) => {
             oldState.connection.attempts = 0;
             oldState.authorization.token = authToken;
+            oldState.storage.state = StorageState.Loading;
             oldState.webSocket = webSocket;
 
             return oldState;
@@ -460,6 +463,10 @@ export class PluvRoom<
         this._updateState((oldState) => {
             oldState.authorization.token = null;
             oldState.connection.state = ConnectionState.Closed;
+            oldState.storage.state =
+                oldState.storage.state === StorageState.Synced
+                    ? StorageState.Offline
+                    : StorageState.Unavailable;
             oldState.webSocket = null;
 
             return oldState;
@@ -1041,7 +1048,6 @@ export class PluvRoom<
         const state = data.state;
 
         this._updateState((oldState) => {
-            oldState.connection.count += 1;
             oldState.connection.id = connectionId;
             oldState.authorization.user = user ?? null;
 
@@ -1115,6 +1121,11 @@ export class PluvRoom<
         this._emitSharedTypes();
         this._observeCrdt();
         this._stateNotifier.subjects["storage-loaded"].next(true);
+        this._updateState((oldState) => {
+            oldState.storage.state = StorageState.Synced;
+
+            return oldState;
+        });
 
         this._sendMessage({
             type: "$updateStorage",
@@ -1277,6 +1288,7 @@ export class PluvRoom<
 
         this._updateState((oldState) => {
             oldState.connection.state = ConnectionState.Unavailable;
+            oldState.storage.state = StorageState.Unavailable;
 
             return oldState;
         });
@@ -1312,6 +1324,10 @@ export class PluvRoom<
                    * @date April 28, 2025
                    */
                   ConnectionState.Closed;
+            oldState.storage.state =
+                oldState.storage.state === StorageState.Synced
+                    ? StorageState.Offline
+                    : StorageState.Unavailable;
             oldState.webSocket = null;
 
             return oldState;
@@ -1412,6 +1428,10 @@ export class PluvRoom<
 
         this._updateState((oldState) => {
             oldState.connection.state = ConnectionState.Unavailable;
+            oldState.storage.state =
+                oldState.storage.state === StorageState.Synced
+                    ? StorageState.Offline
+                    : StorageState.Unavailable;
 
             return oldState;
         });
@@ -1562,6 +1582,7 @@ export class PluvRoom<
             ...this._state,
             authorization,
             connection: JSON.parse(JSON.stringify(this._state.connection)),
+            storage: JSON.parse(JSON.stringify(this._state.storage)),
             webSocket: this._state.webSocket,
         };
 

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -307,7 +307,10 @@ export class PluvRoom<
     }
 
     public get storageLoaded(): boolean {
-        return this._crdtManager.initialized;
+        return (
+            this._state.storage.state === StorageState.Offline ||
+            this._state.storage.state === StorageState.Synced
+        );
     }
 
     public get webSocket(): WebSocket | null {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -9,6 +9,7 @@ export type {
     MergeEvents,
     RoomLike,
     UserInfo,
+    WebSocketConnection,
     WebSocketState,
 } from "@pluv/types";
 export { AbstractStorageStore } from "./AbstractStorageStore";
@@ -32,4 +33,4 @@ export type {
 export type { PluvRouter, PluvRouterEventConfig } from "./PluvRouter";
 export { register } from "./register";
 export type { RegisterParams } from "./register";
-export type { InferMetadata, PublicKey, PublicKeyParams, WebSocketConnection } from "./types";
+export type { InferMetadata, PublicKey, PublicKeyParams } from "./types";

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,6 +1,5 @@
 import type { CrdtType } from "@pluv/crdt";
 import type {
-    ConnectionState,
     CrdtDocLike,
     EventRecord,
     Id,
@@ -75,25 +74,6 @@ export interface PublicKeyParams<TMetadata extends JsonObject> {
 export type PublicKey<TMetadata extends JsonObject> =
     | string
     | ((params: PublicKeyParams<TMetadata>) => string);
-
-export interface WebSocketConnection {
-    /**
-     * @description How many times a connection attempt was made. This will increment upon each
-     * unsuccessful attempt, and will reset upon a successful connection.
-     * @date April 13, 2025
-     */
-    attempts: number;
-    /**
-     * @description How many times the user has connected to the room. This can be more than 1 in
-     * the case of reconnects. This is tracked because on the very first connection (i.e. when
-     * count is 0) we don't want to send the storage state as an update to the room and overwrite
-     * the upstream state.
-     * @date April 13, 2025
-     */
-    count: number;
-    id: string | null;
-    state: ConnectionState;
-}
 
 export type WithMetadata<TMetadata extends JsonObject = {}> = keyof TMetadata extends never
     ? { metadata?: undefined }

--- a/packages/crdt-yjs/src/awareness/PluvYjsAwareness.ts
+++ b/packages/crdt-yjs/src/awareness/PluvYjsAwareness.ts
@@ -212,7 +212,7 @@ export class PluvYjsAwareness extends ObservableV2<{
 
     /**
      * !HACK
-     * @description We dgaf about these fields. We're just mirroring the fields that exist in the
+     * @description We dgaf about these. We're just mirroring the fields that exist in the
      * og awareness to make sure everything aligns.
      * @see https://github.com/yjs/y-protocols/blob/master/awareness.js
      * @date May 13, 2025

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -15,7 +15,7 @@ export type {
     SpreadProperties,
     UndefinedProps,
 } from "./general";
-export { ConnectionState } from "./pluv";
+export { ConnectionState, StorageState } from "./pluv";
 export type {
     BaseClientEventRecord,
     BaseClientMessage,
@@ -54,6 +54,7 @@ export type {
     ProcedureLike,
     RoomLike,
     StateNotifierSubjects,
+    StorageInfo,
     StorageProxy,
     StorageRootSubscriptionCallback,
     StorageRootSubscriptionFn,

--- a/packages/types/src/pluv/enums.ts
+++ b/packages/types/src/pluv/enums.ts
@@ -1,9 +1,18 @@
 export const ConnectionState = {
-    Closed: "Closed",
-    Connecting: "Connecting",
-    Open: "Open",
-    Unavailable: "Unavailable",
-    Untouched: "Untouched",
+    Closed: "closed",
+    Connecting: "connecting",
+    Open: "open",
+    Unavailable: "unavailable",
+    Untouched: "untouched",
 } as const;
 
 export type ConnectionState = (typeof ConnectionState)[keyof typeof ConnectionState];
+
+export const StorageState = {
+    Loading: "loading",
+    Offline: "offline",
+    Synced: "synced",
+    Unavailable: "unavailable",
+};
+
+export type StorageState = (typeof StorageState)[keyof typeof StorageState];

--- a/packages/types/src/pluv/room.ts
+++ b/packages/types/src/pluv/room.ts
@@ -1,7 +1,7 @@
 import type { Subject } from "wonka";
 import type { Id, JsonObject } from "../general";
 import type { CrdtDocLike, CrdtType, InferCrdtJson } from "./crdt";
-import type { ConnectionState } from "./enums";
+import type { ConnectionState, StorageState } from "./enums";
 import type {
     InferIOAuthorize,
     InferIOAuthorizeUser,
@@ -83,21 +83,18 @@ export interface WebSocketConnection {
      * @date April 13, 2025
      */
     attempts: number;
-    /**
-     * @description How many times the user has connected to the room. This can be more than 1 in
-     * the case of reconnects. This is tracked because on the very first connection (i.e. when
-     * count is 0) we don't want to send the storage state as an update to the room and overwrite
-     * the upstream state.
-     * @date April 13, 2025
-     */
-    count: number;
     id: string | null;
     state: ConnectionState;
+}
+
+export interface StorageInfo {
+    state: StorageState;
 }
 
 export interface WebSocketState<TIO extends IOLike> {
     authorization: AuthorizationState<TIO>;
     connection: WebSocketConnection;
+    storage: StorageInfo;
     webSocket: WebSocket | null;
 }
 

--- a/packages/types/src/pluv/room.ts
+++ b/packages/types/src/pluv/room.ts
@@ -185,8 +185,6 @@ export interface RoomLike<
     TEvents extends PluvRouterEventConfig = {},
 > {
     id: string;
-    storageLoaded: boolean;
-
     broadcast: BroadcastProxy<TIO, TEvents>;
 
     canRedo(): boolean;
@@ -211,6 +209,8 @@ export interface RoomLike<
 
     getStorageJson(): InferCrdtJson<TStorage> | null;
     getStorageJson<TKey extends keyof TStorage>(type: TKey): InferCrdtJson<TStorage[TKey]> | null;
+
+    getStorageLoaded: () => boolean;
 
     other(connectionId: string, callback: OtherSubscriptionCallback<TIO, TPresence>): () => void;
 

--- a/packages/types/src/pluv/room.ts
+++ b/packages/types/src/pluv/room.ts
@@ -186,6 +186,10 @@ export interface RoomLike<
 > {
     id: string;
     broadcast: BroadcastProxy<TIO, TEvents>;
+    /**
+     * @deprecated To be removed in v3. Use getStorageLoaded instead.
+     */
+    storageLoaded: boolean;
 
     canRedo(): boolean;
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

**DEPRECATED** `PluvRoom.storageLoaded` . Added `PluvRoom.getStorageLoaded` with improved detection of when the storage was synced.