### PR TITLE
feat(client): ws event listeners

### DIFF
--- a/.changeset/plenty-toes-dance.md
+++ b/.changeset/plenty-toes-dance.md
@@ -1,0 +1,5 @@
+---
+"@pluv/client": minor
+---
+
+Added the ability to listen to the room's underlying websocket's event listeners.

--- a/packages/client/src/ListenerManager.ts
+++ b/packages/client/src/ListenerManager.ts
@@ -1,0 +1,21 @@
+import { makeSubject, subscribe, TypeOfSource } from "wonka";
+
+export class ListenerManager {
+    public subjects = {
+        close: makeSubject<CloseEvent>(),
+        error: makeSubject<Event>(),
+        message: makeSubject<MessageEvent<any>>(),
+        open: makeSubject<Event>(),
+    };
+
+    public subscribe<TKind extends keyof typeof this.subjects>(
+        kind: TKind,
+        callback: (event: TypeOfSource<(typeof this.subjects)[TKind]["source"]>) => void,
+    ): () => void {
+        const source = this.subjects[kind]?.source;
+
+        if (!source) return () => undefined;
+
+        return subscribe(callback)(source as any).unsubscribe;
+    }
+}

--- a/packages/client/src/MockedRoom.ts
+++ b/packages/client/src/MockedRoom.ts
@@ -12,6 +12,7 @@ import type {
     MergeEvents,
     OtherSubscriptionCallback,
     OthersSubscriptionCallback,
+    RoomEventListenerMap,
     RoomLike,
     StateNotifierSubjects,
     StorageProxy,
@@ -126,6 +127,13 @@ export class MockedRoom<
         });
 
         this._observeCrdt();
+    }
+
+    public addEventListener<TKind extends keyof RoomEventListenerMap>(
+        kind: TKind,
+        handler: RoomEventListenerMap[TKind],
+    ): () => void {
+        return () => undefined;
     }
 
     public broadcast = new Proxy(

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -52,6 +52,7 @@ export type {
     OtherSubscriptionCallback,
     OtherSubscriptionFn,
     ProcedureLike,
+    RoomEventListenerMap,
     RoomLike,
     StateNotifierSubjects,
     StorageInfo,

--- a/packages/types/src/pluv/room.ts
+++ b/packages/types/src/pluv/room.ts
@@ -178,6 +178,13 @@ export type SubscribeProxy<
     storageLoaded: SubscribeFn<boolean>;
 };
 
+export interface RoomEventListenerMap {
+    close: (event: CloseEvent | null) => void;
+    error: (event: Event) => void;
+    message: (event: MessageEvent<any>) => void;
+    open: (event: Event) => void;
+}
+
 export interface RoomLike<
     TIO extends IOLike,
     TPresence extends JsonObject = {},
@@ -190,6 +197,11 @@ export interface RoomLike<
      * @deprecated To be removed in v3. Use getStorageLoaded instead.
      */
     storageLoaded: boolean;
+
+    addEventListener<TKind extends keyof RoomEventListenerMap>(
+        kind: TKind,
+        handler: RoomEventListenerMap[TKind],
+    ): () => void;
 
     canRedo(): boolean;
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Added the ability to listen to the room's underlying websocket's event listeners.