### PR TITLE
feat(client): lenient presence type

### DIFF
--- a/.changeset/pretty-mammals-sleep.md
+++ b/.changeset/pretty-mammals-sleep.md
@@ -1,0 +1,5 @@
+---
+"@pluv/client": minor
+---
+
+Updated `presence` types to be more lenient (i.e. no-longer extends `JsonObject`). This is to enable types like `.passthrough` with zod, which can be useful for integrating `yjs.awareness` with libraries such as [lexical](https://lexical.dev/).

--- a/packages/addon-indexeddb/src/addonIndexedDB.ts
+++ b/packages/addon-indexeddb/src/addonIndexedDB.ts
@@ -6,7 +6,7 @@ import { IndexedDBStorage } from "./IndexedDBStorage";
 export interface AddonIndexedDBConfig<
     TIO extends IOLike<any, any>,
     TMetadata extends JsonObject,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
 > {
     enabled?: boolean | ((room: PluvRoom<TIO, TMetadata, TPresence, TCrdt>) => boolean);
@@ -15,7 +15,7 @@ export interface AddonIndexedDBConfig<
 export const addonIndexedDB = <
     TIO extends IOLike<any, any>,
     TMetadata extends JsonObject,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
 >(
     config?: AddonIndexedDBConfig<TIO, TMetadata, TPresence, TCrdt>,

--- a/packages/client/src/MockedRoom.ts
+++ b/packages/client/src/MockedRoom.ts
@@ -57,7 +57,7 @@ export type MockedRoomEvents<TIO extends IOLike> = Partial<{
 
 export type MockedRoomConfig<
     TIO extends IOLike,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
     TEvents extends PluvRouterEventConfig<TIO, TPresence, InferStorage<TCrdt>>,
 > = {
@@ -69,7 +69,7 @@ export type MockedRoomConfig<
 
 export class MockedRoom<
     TIO extends IOLike,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
     TEvents extends PluvRouterEventConfig<TIO, TPresence, InferStorage<TCrdt>>,
 > implements RoomLike<TIO, InferDoc<TCrdt>, TPresence, InferStorage<TCrdt>>

--- a/packages/client/src/PluvClient.ts
+++ b/packages/client/src/PluvClient.ts
@@ -24,7 +24,7 @@ import type { PluvClientLimits, PublicKey, WithMetadata } from "./types";
 
 export type PluvClientOptions<
     TIO extends IOLike<any, any>,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
     TMetadata extends JsonObject,
 > = RoomEndpoints<TIO, TMetadata> & {
@@ -43,7 +43,7 @@ export type PluvClientOptions<
 
 export type CreateRoomOptions<
     TIO extends IOLike<any, any>,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
     TMetadata extends JsonObject,
     TEvents extends PluvRouterEventConfig<TIO, TPresence, InferStorage<TCrdt>> = {},
@@ -63,7 +63,7 @@ export type EnterRoomParams<TMetadata extends JsonObject = {}> = keyof TMetadata
 
 export class PluvClient<
     TIO extends IOLike<any, any>,
-    TPresence extends JsonObject = {},
+    TPresence extends Record<string, any> = {},
     TCrdt extends AbstractCrdtDocFactory<any, any> = NoopCrdtDocFactory,
     TMetadata extends JsonObject = {},
 > {

--- a/packages/client/src/PluvProcedure.ts
+++ b/packages/client/src/PluvProcedure.ts
@@ -6,7 +6,7 @@ export interface PluvProcedureConfig<
     TIO extends IOLike,
     TInput extends JsonObject,
     TOutput extends EventRecord<string, any>,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
 > {
     broadcast?: EventResolver<TIO, TInput, TOutput, TPresence, InferDocLike<TCrdt>> | null;
@@ -17,7 +17,7 @@ export class PluvProcedure<
     TIO extends IOLike,
     TInput extends JsonObject,
     TOutput extends EventRecord<string, any>,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
     TFilled extends "input" | "broadcast" | "",
 > implements ProcedureLike<TInput, TOutput>

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -89,7 +89,7 @@ declare global {
 export const DEFAULT_PLUV_CLIENT_ADDON = <
     TIO extends IOLike,
     TMetadata extends JsonObject,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
 >(
     input: PluvRoomAddonInput<TIO, TMetadata, TPresence, TCrdt>,
@@ -147,14 +147,14 @@ interface InternalListeners {
 export type PluvRoomAddon<
     TIO extends IOLike,
     TMetadata extends JsonObject,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
 > = (input: PluvRoomAddonInput<TIO, TMetadata, TPresence, TCrdt>) => Partial<PluvRoomAddonResult>;
 
 export interface PluvRoomAddonInput<
     TIO extends IOLike,
     TMetadata extends JsonObject,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
 > {
     room: PluvRoom<TIO, TMetadata, TPresence, TCrdt>;
@@ -185,7 +185,7 @@ export type ReconnectTimeoutMs = number | ((params: ReconnectTimeoutMsParams) =>
 export type RoomConfig<
     TIO extends IOLike,
     TMetadata extends JsonObject,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
     TEvents extends PluvRouterEventConfig<TIO, TPresence, InferStorage<TCrdt>>,
 > = Id<
@@ -206,7 +206,7 @@ export type RoomConfig<
 export class PluvRoom<
     TIO extends IOLike<any, any>,
     TMetadata extends JsonObject = {},
-    TPresence extends JsonObject = {},
+    TPresence extends Record<string, any> = {},
     TCrdt extends AbstractCrdtDocFactory<any, any> = NoopCrdtDocFactory,
     TEvents extends PluvRouterEventConfig<TIO, TPresence, InferStorage<TCrdt>> = {},
 > implements RoomLike<TIO, InferDoc<TCrdt>, TPresence, InferStorage<TCrdt>>

--- a/packages/client/src/PluvRouter.ts
+++ b/packages/client/src/PluvRouter.ts
@@ -4,14 +4,14 @@ import type { PluvProcedure } from "./PluvProcedure";
 
 export type PluvRouterEventConfig<
     TIO extends IOLike,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
 > = { [P: string]: Pick<PluvProcedure<TIO, any, any, TPresence, TCrdt, "">, "config"> };
 
 export type MergedRouter<
     TRouters extends PluvRouter<TIO, TPresence, TCrdt, any>[],
     TIO extends IOLike,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
     TRoot extends TRouters[0]["_defs"]["events"],
 > = TRouters extends [
@@ -23,7 +23,7 @@ export type MergedRouter<
 
 export class PluvRouter<
     TIO extends IOLike,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
     TEvents extends PluvRouterEventConfig<TIO, TPresence, TCrdt> = {},
 > implements IORouterLike<TEvents>
@@ -45,7 +45,7 @@ export class PluvRouter<
     public static merge<
         TRouters extends PluvRouter<TIO, TPresence, TCrdt, any>[],
         TIO extends IOLike,
-        TPresence extends JsonObject,
+        TPresence extends Record<string, any>,
         TCrdt extends AbstractCrdtDocFactory<any, any>,
     >(...routers: TRouters): MergedRouter<TRouters, TIO, TPresence, TCrdt, {}> {
         const events = Object.assign(

--- a/packages/client/src/StateNotifier.ts
+++ b/packages/client/src/StateNotifier.ts
@@ -12,14 +12,14 @@ import { makeSubject, subscribe } from "wonka";
 
 type InferSubjectValue<
     TIO extends IOLike,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TSubject extends keyof StateNotifierSubjects<TIO, TPresence>,
 > =
     StateNotifierSubjects<TIO, TPresence>[TSubject] extends Subject<infer IValue>
         ? Id<IValue>
         : never;
 
-export class StateNotifier<TIO extends IOLike, TPresence extends JsonObject = {}> {
+export class StateNotifier<TIO extends IOLike, TPresence extends Record<string, any> = {}> {
     public subjects: StateNotifierSubjects<TIO, TPresence> = {
         connection: makeSubject<Id<WebSocketState<TIO>>>(),
         "my-presence": makeSubject<TPresence>(),

--- a/packages/client/src/UsersManager.ts
+++ b/packages/client/src/UsersManager.ts
@@ -5,26 +5,29 @@ import { pickBy } from "./utils";
 
 export type Presence = Record<string, unknown>;
 
-export type UsersManagerConfig<TPresence extends JsonObject = {}> = {
+export type UsersManagerConfig<TPresence extends Record<string, any> = {}> = {
     initialPresence?: TPresence;
     limits: PluvClientLimits;
     presence?: InputZodLike<TPresence>;
 };
 
-export type AddConnectionResult<TIO extends IOLike, TPresence extends JsonObject = {}> = {
+export type AddConnectionResult<TIO extends IOLike, TPresence extends Record<string, any> = {}> = {
     clientId: string;
     data: UserInfo<TIO, TPresence>;
     isMyself: boolean;
     remaining: number;
 };
 
-export type DeleteConnectionResult<TIO extends IOLike, TPresence extends JsonObject = {}> = {
+export type DeleteConnectionResult<
+    TIO extends IOLike,
+    TPresence extends Record<string, any> = {},
+> = {
     clientId: string;
     data: UserInfo<TIO, TPresence>;
     remaining: number;
 };
 
-export class UsersManager<TIO extends IOLike, TPresence extends JsonObject = {}> {
+export class UsersManager<TIO extends IOLike, TPresence extends Record<string, any> = {}> {
     public readonly initialPresence: TPresence;
 
     private readonly _idMap = {

--- a/packages/client/src/UsersNotifier.ts
+++ b/packages/client/src/UsersNotifier.ts
@@ -10,7 +10,7 @@ import type {
 import type { Subject } from "wonka";
 import { makeSubject, subscribe, TypeOfSource } from "wonka";
 
-export class UsersNotifier<TIO extends IOLike, TPresence extends JsonObject = {}> {
+export class UsersNotifier<TIO extends IOLike, TPresence extends Record<string, any> = {}> {
     public readonly others = makeSubject<{
         others: readonly Id<UserInfo<TIO, TPresence>>[];
         event: OthersSubscriptionEvent<TIO, TPresence>;

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -5,7 +5,7 @@ import { PluvClient } from "./PluvClient";
 
 export const createClient = <
     TIO extends IOLike<any, any>,
-    TPresence extends JsonObject = {},
+    TPresence extends Record<string, any> = {},
     TCrdt extends AbstractCrdtDocFactory<any, any> = NoopCrdtDocFactory,
     TMetadata extends JsonObject = {},
 >(

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -21,7 +21,7 @@ export type EventResolver<
     TIO extends IOLike,
     TInput extends JsonObject,
     TOutput extends EventRecord<string, any>,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TDocLike extends CrdtDocLike<any, any>,
 > = (
     data: TInput,
@@ -30,7 +30,7 @@ export type EventResolver<
 
 export interface EventResolverContext<
     TIO extends IOLike,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TDocLike extends CrdtDocLike<any, any>,
 > {
     doc: TDocLike;

--- a/packages/crdt-yjs/src/awareness/PluvYjsAwareness.ts
+++ b/packages/crdt-yjs/src/awareness/PluvYjsAwareness.ts
@@ -14,7 +14,7 @@ import type { MetaClientState, YjsAwarenessUpdate } from "../types";
 
 export interface PluvYjsAwarenessParams<
     TIO extends IOLike<any>,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TStorage extends Record<string, CrdtType<any, any>>,
     TEvents extends PluvRouterEventConfig,
 > {
@@ -24,7 +24,7 @@ export interface PluvYjsAwarenessParams<
 
 export class PluvYjsAwareness<
     TIO extends IOLike,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TStorage extends Record<string, CrdtType<any, any>>,
     TEvents extends PluvRouterEventConfig,
 > extends ObservableV2<{

--- a/packages/crdt-yjs/src/awareness/awareness.ts
+++ b/packages/crdt-yjs/src/awareness/awareness.ts
@@ -4,7 +4,7 @@ import { PluvYjsAwareness } from "./PluvYjsAwareness";
 
 export const awareness = <
     TIO extends IOLike<any>,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TStorage extends Record<string, CrdtType<any, any>>,
     TEvents extends PluvRouterEventConfig,
 >(

--- a/packages/crdt-yjs/src/provider/PluvYjsProvider.ts
+++ b/packages/crdt-yjs/src/provider/PluvYjsProvider.ts
@@ -8,7 +8,7 @@ import type { YjsProviderStatus } from "../types";
 
 export interface PluvYjsProviderParams<
     TIO extends IOLike<any>,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TStorage extends Record<string, CrdtType<any, any>>,
     TEvents extends PluvRouterEventConfig,
 > {
@@ -24,7 +24,7 @@ export interface PluvYjsProviderParams<
  */
 export class PluvYjsProvider<
     TIO extends IOLike<any>,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TStorage extends Record<string, CrdtType<any, any>>,
     TEvents extends PluvRouterEventConfig,
 > extends ObservableV2<{

--- a/packages/crdt-yjs/src/provider/provider.ts
+++ b/packages/crdt-yjs/src/provider/provider.ts
@@ -4,7 +4,7 @@ import { PluvYjsProvider } from "./PluvYjsProvider";
 
 export const provider = <
     TIO extends IOLike<any>,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TStorage extends Record<string, CrdtType<any, any>>,
     TEvents extends PluvRouterEventConfig,
 >(

--- a/packages/react/src/createBundle.tsx
+++ b/packages/react/src/createBundle.tsx
@@ -49,7 +49,7 @@ export interface PluvProviderProps {
 }
 
 type BaseRoomProviderProps<
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
 > = {
     children?: ReactNode;
@@ -59,7 +59,7 @@ type BaseRoomProviderProps<
 
 export type MockedRoomProviderProps<
     TIO extends IOLike,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
     TEvents extends PluvRouterEventConfig<TIO, TPresence, InferStorage<TCrdt>> = {},
 > = BaseRoomProviderProps<TPresence, TCrdt> & {
@@ -73,7 +73,7 @@ export type MetadataGetter<TMetadata extends JsonObject> =
 export type PluvRoomProviderProps<
     TIO extends IOLike<any, any>,
     TMetadata extends JsonObject,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
 > = BaseRoomProviderProps<TPresence, TCrdt> & {
     connect?: boolean;
@@ -87,7 +87,7 @@ export interface SubscriptionHookOptions<T extends unknown> {
     isEqual?: (a: T, b: T) => boolean;
 }
 
-export type UpdateMyPresenceAction<TPresence extends JsonObject> =
+export type UpdateMyPresenceAction<TPresence extends Record<string, any>> =
     | Partial<TPresence>
     | ((oldPresence: TPresence | null) => Partial<TPresence>);
 
@@ -107,7 +107,7 @@ export type EventProxy<TIO extends IOLike> = {
 export interface CreateBundle<
     TIO extends IOLike<any>,
     TMetadata extends JsonObject,
-    TPresence extends JsonObject = {},
+    TPresence extends Record<string, any> = {},
     TCrdt extends AbstractCrdtDocFactory<any, any> = NoopCrdtDocFactory,
     TEvents extends PluvRouterEventConfig<TIO, TPresence, InferStorage<TCrdt>> = {},
 > {
@@ -167,7 +167,7 @@ export interface CreateBundle<
 export type CreateBundleOptions<
     TIO extends IOLike<any>,
     TMetadata extends JsonObject = {},
-    TPresence extends JsonObject = {},
+    TPresence extends Record<string, any> = {},
     TCrdt extends AbstractCrdtDocFactory<any, any> = NoopCrdtDocFactory,
     TEvents extends PluvRouterEventConfig<TIO, TPresence, InferStorage<TCrdt>> = {},
 > = {
@@ -178,7 +178,7 @@ export type CreateBundleOptions<
 export const createBundle = <
     TIO extends IOLike<any, any>,
     TMetadata extends JsonObject = {},
-    TPresence extends JsonObject = {},
+    TPresence extends Record<string, any> = {},
     TCrdt extends AbstractCrdtDocFactory<any, any> = NoopCrdtDocFactory,
     TEvents extends PluvRouterEventConfig<TIO, TPresence, InferStorage<TCrdt>> = {},
 >(

--- a/packages/types/src/pluv/room.ts
+++ b/packages/types/src/pluv/room.ts
@@ -18,32 +18,35 @@ export interface AuthorizationState<TIO extends IOLike> {
     user: Id<InferIOAuthorizeUser<InferIOAuthorize<TIO>>> | null;
 }
 
-export type OtherSubscriptionCallback<TIO extends IOLike, TPresence extends JsonObject> = (
+export type OtherSubscriptionCallback<TIO extends IOLike, TPresence extends Record<string, any>> = (
     value: Id<UserInfo<TIO, TPresence>> | null,
 ) => void;
 
-export type OtherSubscriptionFn<TIO extends IOLike, TPresence extends JsonObject> = (
+export type OtherSubscriptionFn<TIO extends IOLike, TPresence extends Record<string, any>> = (
     connectionId: string,
     callback: OtherSubscriptionCallback<TIO, TPresence>,
 ) => () => void;
 
-export type OthersSubscriptionEvent<TIO extends IOLike, TPresence extends JsonObject> =
+export type OthersSubscriptionEvent<TIO extends IOLike, TPresence extends Record<string, any>> =
     | { kind: "clear" }
     | { kind: "enter"; user: Id<UserInfo<TIO, TPresence>> }
     | { kind: "leave"; user: Id<UserInfo<TIO, TPresence>> }
     | { kind: "sync"; users: readonly Id<UserInfo<TIO, TPresence>>[] }
     | { kind: "update"; user: Id<UserInfo<TIO, TPresence>> };
 
-export type OthersSubscriptionCallback<TIO extends IOLike, TPresence extends JsonObject> = (
+export type OthersSubscriptionCallback<
+    TIO extends IOLike,
+    TPresence extends Record<string, any>,
+> = (
     value: readonly Id<UserInfo<TIO, TPresence>>[],
     event: OthersSubscriptionEvent<TIO, TPresence>,
 ) => void;
 
-export type OthersSubscriptionFn<TIO extends IOLike, TPresence extends JsonObject> = (
+export type OthersSubscriptionFn<TIO extends IOLike, TPresence extends Record<string, any>> = (
     callback: OthersSubscriptionCallback<TIO, TPresence>,
 ) => () => void;
 
-export interface StateNotifierSubjects<TIO extends IOLike, TPresence extends JsonObject> {
+export interface StateNotifierSubjects<TIO extends IOLike, TPresence extends Record<string, any>> {
     connection: Subject<Id<WebSocketState<TIO>>>;
     "my-presence": Subject<TPresence | null>;
     myself: Subject<Readonly<Id<UserInfo<TIO, TPresence>>> | null>;
@@ -53,7 +56,7 @@ export interface StateNotifierSubjects<TIO extends IOLike, TPresence extends Jso
 
 type InferSubjectValue<
     TIO extends IOLike,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TSubject extends keyof StateNotifierSubjects<TIO, TPresence>,
 > =
     StateNotifierSubjects<TIO, TPresence>[TSubject] extends Subject<infer IValue>
@@ -62,15 +65,15 @@ type InferSubjectValue<
 
 export type SubscriptionCallback<
     TIO extends IOLike,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TSubject extends keyof StateNotifierSubjects<TIO, TPresence>,
 > = (value: InferSubjectValue<TIO, TPresence, TSubject>) => void;
 
-export type UpdateMyPresenceAction<TPresence extends JsonObject> =
+export type UpdateMyPresenceAction<TPresence extends Record<string, any>> =
     | Partial<TPresence>
     | ((oldPresence: TPresence | null) => Partial<TPresence>);
 
-export interface UserInfo<TIO extends IOLike, TPresence extends JsonObject = {}> {
+export interface UserInfo<TIO extends IOLike, TPresence extends Record<string, any> = {}> {
     connectionId: string;
     presence: TPresence;
     user: Id<InferIOAuthorizeUser<InferIOAuthorize<TIO>>>;
@@ -161,7 +164,7 @@ export type SubscribeFn<TValue extends unknown> = (callback: (value: TValue) => 
 
 export type SubscribeProxy<
     TIO extends IOLike,
-    TPresence extends JsonObject,
+    TPresence extends Record<string, any>,
     TStorage extends Record<string, CrdtType<any, any>>,
     TEvents extends PluvRouterEventConfig,
 > = (<TSubject extends keyof StateNotifierSubjects<TIO, TPresence>>(
@@ -188,7 +191,7 @@ export interface RoomEventListenerMap {
 export interface RoomLike<
     TIO extends IOLike,
     TDoc extends any,
-    TPresence extends JsonObject = {},
+    TPresence extends Record<string, any> = {},
     TStorage extends Record<string, CrdtType<any, any>> = {},
     TEvents extends PluvRouterEventConfig = {},
 > {

--- a/tests/types/src/types.test.tsx
+++ b/tests/types/src/types.test.tsx
@@ -50,6 +50,9 @@ const client = createClient({
     initialStorage: yjs.doc((t) => ({
         messages: t.array<string>("messages"),
     })),
+    presence: z.object({
+        cursor: z.nullable(z.object({ x: z.number(), y: z.number() })),
+    }),
     types,
 });
 
@@ -110,6 +113,19 @@ room.subscribe.storage("messages", (messages) => {
 room.subscribe.storage.messages((messages) => {
     expectTypeOf<typeof messages>().toEqualTypeOf<string[]>();
 });
+room.subscribe.myPresence((myPresence) => {
+    expectTypeOf<typeof myPresence>().toEqualTypeOf<{
+        cursor: { x: number; y: number } | null;
+    } | null>();
+
+    // @ts-expect-error
+    expectTypeOf<typeof myPresence>().toEqualTypeOf<{
+        invalidKey: { x: number; y: number } | null;
+    } | null>();
+
+    // @ts-expect-error
+    expectTypeOf<typeof myPresence>().toEqualTypeOf<{ cursor: number }>();
+});
 
 expectTypeOf(room.getDoc()).toEqualTypeOf<
     CrdtDocLike<
@@ -123,6 +139,9 @@ expectTypeOf(room.getDoc()).toEqualTypeOf<
 const { PluvRoomProvider, useDoc, useStorage } = createBundle(client);
 
 <PluvRoomProvider
+    initialPresence={{
+        cursor: null,
+    }}
     initialStorage={(t) => ({
         messages: t.array("messages"),
     })}


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Updated `presence` types to be more lenient (i.e. no-longer extends `JsonObject`). This is to enable types like `.passthrough` with zod, which can be useful for integrating `yjs.awareness` with libraries such as [lexical](https://lexical.dev/).