### PR TITLE
feat(crdt-yjs): enable setting up awareness on a nested field

### DIFF
--- a/.changeset/kind-geckos-punch.md
+++ b/.changeset/kind-geckos-punch.md
@@ -1,0 +1,41 @@
+---
+"@pluv/crdt-yjs": minor
+---
+
+Update `yjs.awareness` and `yjs.provider` to allow for a `field` parameter to use awareness on a nested presence field.
+
+```ts
+createClient({
+    presence: z.object({
+        topField: z.number(),
+        forAwareness: z.object({
+            nestedField: z.number(),
+        }),
+    }),
+});
+
+yjs.provider({
+    // ...
+    // Optional field to use a nested field, instead of the presence root
+    field: "forAwareness",
+});
+
+yjs.awareness({
+    // ...
+    // Optional field to use a nested field, instead of the presence root
+    field: "forAwareness",
+});
+```
+
+This allows better integrations with [lexical](https://lexical.dev), since they have their own presence types.
+
+```tsx
+createClient({
+    presence: z.object({
+        topField: z.number(),
+        lexical: z.any(),
+    }),
+});
+
+yjs.provider({ field: "lexical" });
+```

--- a/packages/crdt-yjs/src/awareness/PluvYjsAwareness.ts
+++ b/packages/crdt-yjs/src/awareness/PluvYjsAwareness.ts
@@ -94,8 +94,6 @@ export class PluvYjsAwareness<
             ? { [this._field]: state }
             : state) as unknown as Partial<TPresence>;
 
-        console.log("patch", patch);
-
         this._room.updateMyPresence(patch);
 
         this.emit("update", [{ added: [], updated: [this.clientID], removed: [] }, "local"]);
@@ -114,8 +112,6 @@ export class PluvYjsAwareness<
         const patch = (!!this._field
             ? { [this._field]: { ...this.getLocalState(), [field]: value } }
             : { [field]: value }) as unknown as Partial<TPresence>;
-
-        console.log("patch", patch);
 
         this._room.updateMyPresence(patch);
     }

--- a/packages/crdt-yjs/src/awareness/awareness.ts
+++ b/packages/crdt-yjs/src/awareness/awareness.ts
@@ -7,8 +7,9 @@ export const awareness = <
     TPresence extends Record<string, any>,
     TStorage extends Record<string, CrdtType<any, any>>,
     TEvents extends PluvRouterEventConfig,
+    TField extends keyof TPresence | null = null,
 >(
-    params: PluvYjsAwarenessParams<TIO, TPresence, TStorage, TEvents>,
-): PluvYjsAwareness<TIO, TPresence, TStorage, TEvents> => {
+    params: PluvYjsAwarenessParams<TIO, TPresence, TStorage, TEvents, TField>,
+): PluvYjsAwareness<TIO, TPresence, TStorage, TEvents, TField> => {
     return new PluvYjsAwareness(params);
 };

--- a/packages/crdt-yjs/src/provider/PluvYjsProvider.ts
+++ b/packages/crdt-yjs/src/provider/PluvYjsProvider.ts
@@ -1,4 +1,4 @@
-import type { CrdtType, IOLike, JsonObject, PluvRouterEventConfig, RoomLike } from "@pluv/types";
+import type { CrdtType, IOLike, PluvRouterEventConfig, RoomLike } from "@pluv/types";
 import { StorageState } from "@pluv/types";
 import { ObservableV2 } from "lib0/observable";
 import type { Doc as YDoc } from "yjs";
@@ -11,8 +11,10 @@ export interface PluvYjsProviderParams<
     TPresence extends Record<string, any>,
     TStorage extends Record<string, CrdtType<any, any>>,
     TEvents extends PluvRouterEventConfig,
+    TField extends keyof TPresence | null = null,
 > {
     doc: YDoc;
+    field?: TField;
     room: RoomLike<TIO, YDoc, TPresence, TStorage, TEvents>;
 }
 
@@ -27,20 +29,21 @@ export class PluvYjsProvider<
     TPresence extends Record<string, any>,
     TStorage extends Record<string, CrdtType<any, any>>,
     TEvents extends PluvRouterEventConfig,
+    TField extends keyof TPresence | null = null,
 > extends ObservableV2<{
     "connection-close": (
         event: CloseEvent | null,
-        provider: PluvYjsProvider<TIO, TPresence, TStorage, TEvents>,
+        provider: PluvYjsProvider<TIO, TPresence, TStorage, TEvents, TField>,
     ) => void;
     "connection-error": (
         event: Event,
-        provider: PluvYjsProvider<TIO, TPresence, TStorage, TEvents>,
+        provider: PluvYjsProvider<TIO, TPresence, TStorage, TEvents, TField>,
     ) => void;
     status: (event: { status: YjsProviderStatus }) => void;
     sync: (state: boolean) => void;
     synced: (state: boolean) => void;
 }> {
-    public readonly awareness: PluvYjsAwareness<TIO, TPresence, TStorage, TEvents>;
+    public readonly awareness: PluvYjsAwareness<TIO, TPresence, TStorage, TEvents, TField>;
     public readonly doc: YDoc;
 
     private readonly _room: RoomLike<TIO, YDoc, TPresence, TStorage, TEvents>;
@@ -48,12 +51,12 @@ export class PluvYjsProvider<
 
     private _synced: boolean = false;
 
-    constructor(params: PluvYjsProviderParams<TIO, TPresence, TStorage, TEvents>) {
+    constructor(params: PluvYjsProviderParams<TIO, TPresence, TStorage, TEvents, TField>) {
         super();
 
-        const { doc, room } = params;
+        const { doc, field, room } = params;
 
-        this.awareness = awareness({ doc, room });
+        this.awareness = awareness({ doc, field, room });
         this.doc = doc;
 
         this._room = room;

--- a/packages/crdt-yjs/src/provider/provider.ts
+++ b/packages/crdt-yjs/src/provider/provider.ts
@@ -1,4 +1,4 @@
-import type { CrdtType, IOLike, JsonObject, PluvRouterEventConfig } from "@pluv/types";
+import type { CrdtType, IOLike, PluvRouterEventConfig } from "@pluv/types";
 import type { PluvYjsProviderParams } from "./PluvYjsProvider";
 import { PluvYjsProvider } from "./PluvYjsProvider";
 
@@ -7,8 +7,9 @@ export const provider = <
     TPresence extends Record<string, any>,
     TStorage extends Record<string, CrdtType<any, any>>,
     TEvents extends PluvRouterEventConfig,
+    TField extends keyof TPresence | null = null,
 >(
-    params: PluvYjsProviderParams<TIO, TPresence, TStorage, TEvents>,
+    params: PluvYjsProviderParams<TIO, TPresence, TStorage, TEvents, TField>,
 ) => {
     return new PluvYjsProvider(params);
 };

--- a/packages/crdt-yjs/src/types.ts
+++ b/packages/crdt-yjs/src/types.ts
@@ -28,3 +28,8 @@ export interface MetaClientState {
     clock: number;
     lastUpdated: number;
 }
+
+export type AwarenessPresence<
+    TPresence extends Record<string, any>,
+    TField extends keyof TPresence | null,
+> = TField extends null ? TPresence : TField extends keyof TPresence ? TPresence[TField] : never;

--- a/tests/e2e/src/components/yjs/cloudflare/LexicalEditor/LexicalEditor.tsx
+++ b/tests/e2e/src/components/yjs/cloudflare/LexicalEditor/LexicalEditor.tsx
@@ -58,7 +58,7 @@ export const LexicalEditor: FC = () => {
 
             yjsDocMap.set(id, doc);
 
-            return yjs.provider({ doc, room });
+            return yjs.provider({ doc, field: "lexical", room });
         },
         [doc],
     );
@@ -88,7 +88,7 @@ export const LexicalEditor: FC = () => {
                 {/* With CollaborationPlugin - we MUST NOT use @lexical/react/LexicalHistoryPlugin */}
                 <CollaborationPlugin
                     id={room.id}
-                    providerFactory={providerFactory as any}
+                    providerFactory={providerFactory}
                     // Unless you have a way to avoid race condition between 2+ users trying to do bootstrap simultaneously
                     // you should never try to bootstrap on client. It's better to perform bootstrap within Yjs server.
                     shouldBootstrap={false}

--- a/tests/e2e/src/pluv-io/yjs/cloudflare.ts
+++ b/tests/e2e/src/pluv-io/yjs/cloudflare.ts
@@ -40,13 +40,8 @@ const client = createClient({
         authEndpoint: z.string().default("http://localhost:3101"),
     }),
     presence: z.object({
-        anchorPos: z.any().nullable().default(null),
         count: z.number(),
-        color: z.string().default("#000000"),
-        focusing: z.boolean().default(false),
-        focusPos: z.any().nullable().default(null),
-        name: z.string().default(""),
-        awarenessData: z.any().default({}),
+        lexical: z.any().default({}),
     }),
     types,
     wsEndpoint: ({ room }) => {


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Allow specifying Yjs awareness on a custom presence field.