### PR TITLE
feat(crdt-yjs): no longer require doc

### DIFF
--- a/.changeset/fifty-dingos-speak.md
+++ b/.changeset/fifty-dingos-speak.md
@@ -7,12 +7,10 @@ Added a `provider` function that satisfies Yjs's provider interface.
 ```ts
 import { createClient } from "@pluv/client";
 import { yjs } from "@pluv/crdt-yjs";
-import { Doc as YDoc } from "yjs";
 
-const doc = new YDoc();
 const client = createClient({ /* ... */ });
 const room = client.createRoom("example-room");
 
 // Yjs Provider
-yjs.provider({ doc, room });
+yjs.provider({ room });
 ```

--- a/.changeset/kind-geckos-punch.md
+++ b/.changeset/kind-geckos-punch.md
@@ -37,5 +37,5 @@ createClient({
     }),
 });
 
-yjs.provider({ field: "lexical" });
+yjs.provider({ field: "lexical", /* ... */ });
 ```

--- a/.changeset/tricky-humans-run.md
+++ b/.changeset/tricky-humans-run.md
@@ -7,12 +7,10 @@ Added an `awareness` function that satisfies Yjs's [awareness interface](https:/
 ```ts
 import { createClient } from "@pluv/client";
 import { yjs } from "@pluv/crdt-yjs";
-import { Doc as YDoc } from "yjs";
 
-const doc = new YDoc();
 const client = createClient({ /* ... */ });
 const room = client.createRoom("example-room");
 
 // Yjs Awareness
-yjs.awareness({ doc, room });
+yjs.awareness({ room, /* ... */ });
 ```

--- a/packages/crdt-yjs/src/awareness/PluvYjsAwareness.ts
+++ b/packages/crdt-yjs/src/awareness/PluvYjsAwareness.ts
@@ -18,7 +18,6 @@ export interface PluvYjsAwarenessParams<
     TEvents extends PluvRouterEventConfig,
     TField extends keyof TPresence | null = null,
 > {
-    doc: YDoc;
     field?: TField;
     room: RoomLike<TIO, YDoc, TPresence, TStorage, TEvents>;
 }
@@ -52,9 +51,9 @@ export class PluvYjsAwareness<
     constructor(params: PluvYjsAwarenessParams<TIO, TPresence, TStorage, TEvents, TField>) {
         super();
 
-        const { doc, field, room } = params;
+        const { field, room } = params;
 
-        this.doc = doc;
+        this.doc = room.getDoc().value;
         this._room = room;
 
         if (!!field) this._field = field;

--- a/packages/crdt-yjs/src/awareness/awareness.ts
+++ b/packages/crdt-yjs/src/awareness/awareness.ts
@@ -1,4 +1,4 @@
-import type { CrdtType, IOLike, JsonObject, PluvRouterEventConfig } from "@pluv/types";
+import type { CrdtType, IOLike, PluvRouterEventConfig } from "@pluv/types";
 import type { PluvYjsAwarenessParams } from "./PluvYjsAwareness";
 import { PluvYjsAwareness } from "./PluvYjsAwareness";
 

--- a/packages/crdt-yjs/src/provider/PluvYjsProvider.ts
+++ b/packages/crdt-yjs/src/provider/PluvYjsProvider.ts
@@ -13,7 +13,6 @@ export interface PluvYjsProviderParams<
     TEvents extends PluvRouterEventConfig,
     TField extends keyof TPresence | null = null,
 > {
-    doc: YDoc;
     field?: TField;
     room: RoomLike<TIO, YDoc, TPresence, TStorage, TEvents>;
 }
@@ -54,10 +53,10 @@ export class PluvYjsProvider<
     constructor(params: PluvYjsProviderParams<TIO, TPresence, TStorage, TEvents, TField>) {
         super();
 
-        const { doc, field, room } = params;
+        const { field, room } = params;
 
-        this.awareness = awareness({ doc, field, room });
-        this.doc = doc;
+        this.awareness = awareness({ field, room });
+        this.doc = room.getDoc().value;
 
         this._room = room;
 

--- a/tests/e2e/src/components/yjs/cloudflare/BlockNoteEditor/BlockNoteEditorInner.tsx
+++ b/tests/e2e/src/components/yjs/cloudflare/BlockNoteEditor/BlockNoteEditorInner.tsx
@@ -11,9 +11,9 @@ export interface BlockNoteEditorInnerProps {
 }
 
 export const BlockNoteEditorInner: FC<BlockNoteEditorInnerProps> = ({ userName }) => {
-    const { doc, fragment, room } = useContext(BlockNoteEditorContext);
+    const { fragment, room } = useContext(BlockNoteEditorContext);
 
-    const provider = useMemo(() => yjs.provider({ doc, field: "blocknote", room }), [doc, room]);
+    const provider = useMemo(() => yjs.provider({ field: "blocknote", room }), [room]);
     const user = useMemo(
         () => ({ ...getRandomUserProfile(), ...(!!userName ? { name: userName } : {}) }),
         [userName],

--- a/tests/e2e/src/components/yjs/cloudflare/BlockNoteEditor/BlockNoteEditorProvider.tsx
+++ b/tests/e2e/src/components/yjs/cloudflare/BlockNoteEditor/BlockNoteEditorProvider.tsx
@@ -10,14 +10,10 @@ export interface BlockNoteEditorProviderProps {
 
 export const BlockNoteEditorProvider: FC<BlockNoteEditorProviderProps> = ({ children }) => {
     const state = useConnection((connection) => connection.state);
-    const doc = useDoc()?.value ?? null;
     const room = useRoom();
     const [, fragment] = useStorage("blocknote", () => true);
 
-    const value = useMemo(
-        () => (!!fragment ? { doc, fragment, room } : null),
-        [doc, fragment, room],
-    );
+    const value = useMemo(() => (!!fragment ? { fragment, room } : null), [fragment, room]);
 
     if (state !== ConnectionState.Open) return null;
     if (!value) return null;

--- a/tests/e2e/src/components/yjs/cloudflare/BlockNoteEditor/context.ts
+++ b/tests/e2e/src/components/yjs/cloudflare/BlockNoteEditor/context.ts
@@ -1,10 +1,9 @@
 import type { InferBundleRoom } from "@pluv/react";
 import { createContext } from "react";
-import type { Doc as YDoc, XmlFragment as YXmlFragment } from "yjs";
+import type { XmlFragment as YXmlFragment } from "yjs";
 import type { bundle } from "../../../../pluv-io/yjs/cloudflare";
 
 export interface BlockNoteEditorContextValue {
-    doc: YDoc;
     fragment: YXmlFragment;
     room: InferBundleRoom<typeof bundle>;
 }

--- a/tests/e2e/src/components/yjs/cloudflare/LexicalEditor/LexicalEditor.tsx
+++ b/tests/e2e/src/components/yjs/cloudflare/LexicalEditor/LexicalEditor.tsx
@@ -32,18 +32,17 @@ export const LexicalEditor: FC = () => {
     const containerRef = useRef<HTMLDivElement | null>(null);
 
     const room = useRoom();
-    const doc = useDoc().value;
     const connection = useConnection((connection) => connection.state);
 
     const providerFactory = useCallback(
         (id: string, yjsDocMap: Map<string, YDoc>) => {
             if (id !== room.id) throw new Error("Unexpected room id");
 
-            yjsDocMap.set(id, doc);
+            yjsDocMap.set(id, room.getDoc().value);
 
-            return yjs.provider({ doc, field: "lexical", room });
+            return yjs.provider({ field: "lexical", room });
         },
-        [doc],
+        [room],
     );
 
     if (connection !== ConnectionState.Open) return null;


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

No-longer require `doc` in `yjs.awareness` nor `yjs.provider`.