### PR TITLE
fix(io): require get initial storage with crdt

### DIFF
--- a/.changeset/five-cobras-fly.md
+++ b/.changeset/five-cobras-fly.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": patch
+---
+
+Fixed `getInitialStorage` not being required when `crdt` is provided.

--- a/packages/crdt-loro/src/index.ts
+++ b/packages/crdt-loro/src/index.ts
@@ -1,1 +1,5 @@
+import * as loro from "./loro";
+
 export * as loro from "./loro";
+
+export type LoroLibraryType = typeof loro;

--- a/packages/crdt-yjs/src/index.ts
+++ b/packages/crdt-yjs/src/index.ts
@@ -1,1 +1,5 @@
+import * as yjs from "./yjs";
+
 export * as yjs from "./yjs";
+
+export type YjsLibraryType = typeof yjs;

--- a/packages/crdt/src/index.ts
+++ b/packages/crdt/src/index.ts
@@ -11,6 +11,7 @@ export { noop } from "./noop";
 export { NoopCrdtDoc } from "./NoopCrdtDoc";
 export { NoopCrdtDocFactory } from "./NoopCrdtDocFactory";
 export type {
+    CrdtLibraryType,
     InferBuilder,
     InferDoc,
     InferDocLike,

--- a/packages/crdt/src/types.ts
+++ b/packages/crdt/src/types.ts
@@ -1,5 +1,12 @@
 import type { AbstractCrdtDocFactory } from "./AbstractCrdtDocFactory";
 
+export interface CrdtLibraryType<
+    TDoc extends AbstractCrdtDocFactory<any, any> = AbstractCrdtDocFactory<any, any>,
+> {
+    doc: (value: any) => TDoc;
+    kind: "loro" | "yjs";
+}
+
 export type InferDoc<TFactory extends AbstractCrdtDocFactory<any, any>> =
     InferDocLike<TFactory>["value"];
 

--- a/packages/io/src/createIO.ts
+++ b/packages/io/src/createIO.ts
@@ -1,16 +1,19 @@
+import type { CrdtLibraryType, NoopCrdtDocFactory } from "@pluv/crdt";
 import type { BaseUser } from "@pluv/types";
 import type { AbstractPlatform, InferInitContextType } from "./AbstractPlatform";
+import type { PluvIOConfig } from "./PluvIO";
 import { PluvIO } from "./PluvIO";
-import type { CrdtLibraryType, PluvContext, PluvIOAuthorize, PluvIOLimits } from "./types";
+import type { PluvContext, PluvIOAuthorize, PluvIOLimits } from "./types";
 
 export type CreateIOParams<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
     TContext extends Record<string, any> = {},
     TUser extends BaseUser | null = null,
+    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
 > = {
     authorize?: PluvIOAuthorize<TPlatform, TUser, InferInitContextType<TPlatform>>;
     context?: PluvContext<TPlatform, TContext>;
-    crdt?: CrdtLibraryType;
+    crdt?: TCrdt;
     debug?: boolean;
     limits?: PluvIOLimits;
     platform: () => TPlatform;
@@ -20,19 +23,22 @@ export const createIO = <
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
     TContext extends Record<string, any> = {},
     TUser extends BaseUser | null = null,
+    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
 >(
-    params: CreateIOParams<TPlatform, TContext, TUser>,
+    params: CreateIOParams<TPlatform, TContext, TUser, TCrdt>,
 ): PluvIO<
     TPlatform,
     PluvIOAuthorize<TPlatform, TUser, InferInitContextType<TPlatform>>,
-    TContext
+    TContext,
+    TCrdt
 > => {
     const { authorize, context, crdt, debug, limits, platform } = params;
 
     return new PluvIO<
         TPlatform,
         PluvIOAuthorize<TPlatform, TUser, InferInitContextType<TPlatform>>,
-        TContext
+        TContext,
+        TCrdt
     >({
         authorize,
         context,
@@ -40,5 +46,10 @@ export const createIO = <
         debug,
         limits,
         platform,
-    });
+    } as PluvIOConfig<
+        TPlatform,
+        PluvIOAuthorize<TPlatform, TUser, InferInitContextType<TPlatform>>,
+        TContext,
+        TCrdt
+    >);
 };

--- a/packages/io/src/index.ts
+++ b/packages/io/src/index.ts
@@ -1,3 +1,4 @@
+export type { CrdtLibraryType } from "@pluv/crdt";
 export type { BaseUser, EventMessage, EventRecord, IOEventMessage } from "@pluv/types";
 export { AbstractPersistence } from "./AbstractPersistence";
 export { AbstractPlatform } from "./AbstractPlatform";
@@ -35,7 +36,6 @@ export type { MergedRouter, PluvRouterEventConfig } from "./PluvRouter";
 export { PluvServer } from "./PluvServer";
 export type { CreateRoomOptions, InferIORoom, PluvServerConfig } from "./PluvServer";
 export type {
-    CrdtLibraryType,
     GetInitialStorageFn,
     HandleMode,
     IORoomListenerEvent,

--- a/packages/io/src/types.ts
+++ b/packages/io/src/types.ts
@@ -28,11 +28,6 @@ export type PluvContext<TPlatform extends AbstractPlatform, TContext extends Rec
     | TContext
     | ((params: InferRoomContextType<TPlatform>) => TContext);
 
-export interface CrdtLibraryType {
-    doc: (value: any) => AbstractCrdtDocFactory<any, any>;
-    kind: "loro" | "yjs";
-}
-
 export type EventResolverKind = "broadcast" | "self" | "sync";
 
 export type EventResolver<

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -1,38 +1,39 @@
 {
-	"name": "@pluv/platform-cloudflare",
-	"version": "3.0.0",
-	"description": "@pluv/io adapter for cloudflare workers",
-	"author": "leedavidcs",
-	"license": "MIT",
-	"homepage": "https://github.com/pluv-io/pluv",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/pluv-io/pluv.git",
-		"directory": "packages/platform-cloudflare"
-	},
-	"module": "./dist/index.mjs",
-	"types": "./dist/index.d.mts",
-	"publishConfig": {
-		"access": "public"
-	},
-	"scripts": {
-		"build": "tsup src/index.ts",
-		"dev": "tsup src/index.ts --format esm,cjs --watch --dts",
-		"lint": "eslint \"src/**/*.ts*\" --fix --max-warnings 0",
-		"clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
-	},
-	"dependencies": {
-		"@pluv/io": "workspace:^",
-		"@pluv/persistence-cloudflare-transactional-storage": "workspace:^",
-		"@pluv/types": "workspace:^",
-		"path-to-regexp": "^8.2.0"
-	},
-	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20250521.0",
-		"@pluv/tsconfig": "workspace:^",
-		"eslint": "^9.27.0",
-		"eslint-config-pluv": "workspace:^",
-		"tsup": "^8.5.0",
-		"typescript": "^5.8.3"
-	}
+    "name": "@pluv/platform-cloudflare",
+    "version": "3.0.0",
+    "description": "@pluv/io adapter for cloudflare workers",
+    "author": "leedavidcs",
+    "license": "MIT",
+    "homepage": "https://github.com/pluv-io/pluv",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pluv-io/pluv.git",
+        "directory": "packages/platform-cloudflare"
+    },
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsup src/index.ts",
+        "dev": "tsup src/index.ts --format esm,cjs --watch --dts",
+        "lint": "eslint \"src/**/*.ts*\" --fix --max-warnings 0",
+        "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
+    },
+    "dependencies": {
+        "@pluv/crdt": "workspace:^",
+        "@pluv/io": "workspace:^",
+        "@pluv/persistence-cloudflare-transactional-storage": "workspace:^",
+        "@pluv/types": "workspace:^",
+        "path-to-regexp": "^8.2.0"
+    },
+    "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250521.0",
+        "@pluv/tsconfig": "workspace:^",
+        "eslint": "^9.27.0",
+        "eslint-config-pluv": "workspace:^",
+        "tsup": "^8.5.0",
+        "typescript": "^5.8.3"
+    }
 }

--- a/packages/platform-cloudflare/src/platformCloudflare.ts
+++ b/packages/platform-cloudflare/src/platformCloudflare.ts
@@ -1,3 +1,4 @@
+import type { CrdtLibraryType } from "@pluv/crdt";
 import type { CreateIOParams, InferInitContextType, PluvContext, PluvIOAuthorize } from "@pluv/io";
 import type { BaseUser, Id, IOAuthorize, Json } from "@pluv/types";
 import type { CloudflarePlatformConfig } from "./CloudflarePlatform";
@@ -9,13 +10,15 @@ export type PlatformCloudflareCreateIOParams<
     TMeta extends Record<string, Json> = {},
     TContext extends Record<string, any> = {},
     TUser extends BaseUser | null = null,
+    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
 > = Id<
     CloudflarePlatformConfig<TEnv, TMeta> &
         Omit<
             CreateIOParams<
                 CloudflarePlatform<IOAuthorize<TUser, TContext>, TEnv, TMeta>,
                 TContext,
-                TUser
+                TUser,
+                TCrdt
             >,
             "authorize" | "context" | "platform"
         > & {
@@ -37,12 +40,14 @@ export const platformCloudflare = <
     TMeta extends Record<string, Json> = {},
     TContext extends Record<string, any> = {},
     TUser extends BaseUser | null = null,
+    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
 >(
-    config: PlatformCloudflareCreateIOParams<TEnv, TMeta, TContext, TUser> = {},
+    config: PlatformCloudflareCreateIOParams<TEnv, TMeta, TContext, TUser, TCrdt> = {},
 ): CreateIOParams<
     CloudflarePlatform<IOAuthorize<TUser, TContext>, TEnv, TMeta>,
     TContext,
-    TUser
+    TUser,
+    TCrdt
 > => {
     const { authorize, context, crdt, debug, limits } = config;
 

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -1,43 +1,44 @@
 {
-	"name": "@pluv/platform-node",
-	"version": "3.0.0",
-	"description": "@pluv/io adapter for node.js",
-	"author": "leedavidcs",
-	"license": "MIT",
-	"homepage": "https://github.com/pluv-io/pluv",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/pluv-io/pluv.git",
-		"directory": "packages/platform-node"
-	},
-	"main": "./dist/index.js",
-	"module": "./dist/index.mjs",
-	"types": "./dist/index.d.ts",
-	"publishConfig": {
-		"access": "public"
-	},
-	"scripts": {
-		"build": "tsup src/index.ts --format esm,cjs --dts",
-		"dev": "tsup src/index.ts --format esm,cjs --watch --dts",
-		"lint": "eslint \"src/**/*.ts*\" --fix --max-warnings 0",
-		"clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
-	},
-	"dependencies": {
-		"@pluv/io": "workspace:^",
-		"@pluv/types": "workspace:^",
-		"@types/node": "^22.15.21",
-		"@types/ws": "^8.18.1",
-		"path-to-regexp": "^8.2.0"
-	},
-	"devDependencies": {
-		"@pluv/tsconfig": "workspace:^",
-		"eslint": "^9.27.0",
-		"eslint-config-pluv": "workspace:^",
-		"tsup": "^8.5.0",
-		"typescript": "^5.8.3",
-		"ws": "^8.18.2"
-	},
-	"peerDependencies": {
-		"ws": "^8.0.0"
-	}
+    "name": "@pluv/platform-node",
+    "version": "3.0.0",
+    "description": "@pluv/io adapter for node.js",
+    "author": "leedavidcs",
+    "license": "MIT",
+    "homepage": "https://github.com/pluv-io/pluv",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pluv-io/pluv.git",
+        "directory": "packages/platform-node"
+    },
+    "main": "./dist/index.js",
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts",
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsup src/index.ts --format esm,cjs --dts",
+        "dev": "tsup src/index.ts --format esm,cjs --watch --dts",
+        "lint": "eslint \"src/**/*.ts*\" --fix --max-warnings 0",
+        "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
+    },
+    "dependencies": {
+        "@pluv/crdt": "workspace:^",
+        "@pluv/io": "workspace:^",
+        "@pluv/types": "workspace:^",
+        "@types/node": "^22.15.21",
+        "@types/ws": "^8.18.1",
+        "path-to-regexp": "^8.2.0"
+    },
+    "devDependencies": {
+        "@pluv/tsconfig": "workspace:^",
+        "eslint": "^9.27.0",
+        "eslint-config-pluv": "workspace:^",
+        "tsup": "^8.5.0",
+        "typescript": "^5.8.3",
+        "ws": "^8.18.2"
+    },
+    "peerDependencies": {
+        "ws": "^8.0.0"
+    }
 }

--- a/packages/platform-node/src/platformNode.ts
+++ b/packages/platform-node/src/platformNode.ts
@@ -1,10 +1,5 @@
-import type {
-    CreateIOParams,
-    InferInitContextType,
-    PluvContext,
-    PluvIOAuthorize,
-    PluvIOLimits,
-} from "@pluv/io";
+import type { CrdtLibraryType } from "@pluv/crdt";
+import type { CreateIOParams, InferInitContextType, PluvContext, PluvIOAuthorize } from "@pluv/io";
 import type { BaseUser, Id, IOAuthorize, Json } from "@pluv/types";
 import type { NodePlatformConfig } from "./NodePlatform";
 import { NodePlatform } from "./NodePlatform";
@@ -14,10 +9,16 @@ export type PlatformNodeCreateIOParams<
     TMeta extends Record<string, Json> = {},
     TContext extends Record<string, any> = {},
     TUser extends BaseUser | null = null,
+    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
 > = Id<
     NodePlatformConfig<TMeta> &
         Omit<
-            CreateIOParams<NodePlatform<IOAuthorize<TUser, TContext>, TMeta>, TContext, TUser>,
+            CreateIOParams<
+                NodePlatform<IOAuthorize<TUser, TContext>, TMeta>,
+                TContext,
+                TUser,
+                TCrdt
+            >,
             "authorize" | "context" | "platform"
         > & {
             authorize?: PluvIOAuthorize<
@@ -34,9 +35,10 @@ export const platformNode = <
     TMeta extends Record<string, Json> = {},
     TContext extends Record<string, any> = {},
     TUser extends BaseUser | null = null,
+    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
 >(
-    config: PlatformNodeCreateIOParams<TMeta, TContext, TUser> = {},
-): CreateIOParams<NodePlatform<IOAuthorize<TUser, TContext>, TMeta>, TContext, TUser> => {
+    config: PlatformNodeCreateIOParams<TMeta, TContext, TUser, TCrdt> = {},
+): CreateIOParams<NodePlatform<IOAuthorize<TUser, TContext>, TMeta>, TContext, TUser, TCrdt> => {
     const { authorize, context, crdt, debug, limits } = config;
 
     return {

--- a/packages/platform-pluv/src/platformPluv.ts
+++ b/packages/platform-pluv/src/platformPluv.ts
@@ -1,3 +1,4 @@
+import type { CrdtLibraryType } from "@pluv/crdt";
 import type { CreateIOParams, InferInitContextType, PluvContext, PluvIOAuthorize } from "@pluv/io";
 import type { BaseUser, Id } from "@pluv/types";
 import type { PluvPlatformConfig } from "./PluvPlatform";
@@ -6,10 +7,11 @@ import { PluvPlatform } from "./PluvPlatform";
 export type PlatformPluvCreateIOParams<
     TContext extends Record<string, any> = {},
     TUser extends BaseUser = BaseUser,
+    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
 > = Id<
     PluvPlatformConfig &
         Omit<
-            CreateIOParams<PluvPlatform, TContext, TUser>,
+            CreateIOParams<PluvPlatform, TContext, TUser, TCrdt>,
             "authorize" | "context" | "limits" | "platform"
         > & {
             authorize: PluvIOAuthorize<PluvPlatform, TUser, InferInitContextType<PluvPlatform>>;
@@ -20,9 +22,10 @@ export type PlatformPluvCreateIOParams<
 export const platformPluv = <
     TContext extends Record<string, any> = {},
     TUser extends BaseUser = BaseUser,
+    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
 >(
-    config: PlatformPluvCreateIOParams<TContext, TUser>,
-): CreateIOParams<PluvPlatform<TContext, TUser>, TContext, TUser> => {
+    config: PlatformPluvCreateIOParams<TContext, TUser, TCrdt>,
+): CreateIOParams<PluvPlatform<TContext, TUser>, TContext, TUser, TCrdt> => {
     const { authorize, context, crdt, debug } = config;
 
     return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,6 +395,9 @@ importers:
 
   packages/platform-cloudflare:
     dependencies:
+      '@pluv/crdt':
+        specifier: workspace:^
+        version: link:../crdt
       '@pluv/io':
         specifier: workspace:^
         version: link:../io
@@ -429,6 +432,9 @@ importers:
 
   packages/platform-node:
     dependencies:
+      '@pluv/crdt':
+        specifier: workspace:^
+        version: link:../crdt
       '@pluv/io':
         specifier: workspace:^
         version: link:../io

--- a/tests/e2e/src/demo/io.ts
+++ b/tests/e2e/src/demo/io.ts
@@ -25,4 +25,7 @@ const router = io.router({
         .self(({ value }) => ({ DOUBLED_VALUE: { value: value * 2 } })),
 });
 
-export const ioServer = io.server({ router });
+export const ioServer = io.server({
+    getInitialStorage: () => null,
+    router,
+});

--- a/tests/e2e/src/server/loro/node/pluv-io.ts
+++ b/tests/e2e/src/server/loro/node/pluv-io.ts
@@ -25,4 +25,7 @@ const router = io.router({
         .broadcast(({ message }) => ({ RECEIVE_MESSAGE: { message } })),
 });
 
-export const ioServer = io.server({ router });
+export const ioServer = io.server({
+    getInitialStorage: () => null,
+    router,
+});

--- a/tests/e2e/src/server/yjs/cloudflare/pluv-io/kv.ts
+++ b/tests/e2e/src/server/yjs/cloudflare/pluv-io/kv.ts
@@ -24,7 +24,10 @@ export const io = createIO(
 const router = io.router({
     SEND_MESSAGE: io.procedure
         .input(z.object({ message: z.string() }))
-        .broadcast(({ message }, ctx) => ({ RECEIVE_MESSAGE: { message: ctx.session.user } })),
+        .broadcast(({ message }, ctx) => ({ RECEIVE_MESSAGE: { message } })),
 });
 
-export const ioServer = io.server({ router });
+export const ioServer = io.server({
+    getInitialStorage: () => null,
+    router,
+});

--- a/tests/e2e/src/server/yjs/cloudflare/pluv-io/sqlite.ts
+++ b/tests/e2e/src/server/yjs/cloudflare/pluv-io/sqlite.ts
@@ -25,7 +25,10 @@ export const io = createIO(
 const router = io.router({
     SEND_MESSAGE: io.procedure
         .input(z.object({ message: z.string() }))
-        .broadcast(({ message }, ctx) => ({ RECEIVE_MESSAGE: { message: ctx.session.user } })),
+        .broadcast(({ message }, ctx) => ({ RECEIVE_MESSAGE: { message } })),
 });
 
-export const ioServer = io.server({ router });
+export const ioServer = io.server({
+    getInitialStorage: () => null,
+    router,
+});

--- a/tests/e2e/src/server/yjs/node-redis/pluv-io/first.ts
+++ b/tests/e2e/src/server/yjs/node-redis/pluv-io/first.ts
@@ -33,4 +33,7 @@ const router = io.router({
         .broadcast(({ message }) => ({ RECEIVE_MESSAGE: { message } })),
 });
 
-export const ioServer = io.server({ router });
+export const ioServer = io.server({
+    getInitialStorage: () => null,
+    router,
+});

--- a/tests/e2e/src/server/yjs/node-redis/pluv-io/second.ts
+++ b/tests/e2e/src/server/yjs/node-redis/pluv-io/second.ts
@@ -33,4 +33,7 @@ const router = io.router({
         .broadcast(({ message }) => ({ RECEIVE_MESSAGE: { message } })),
 });
 
-export const ioServer = io.server({ router });
+export const ioServer = io.server({
+    getInitialStorage: () => null,
+    router,
+});

--- a/tests/types/src/types.test.tsx
+++ b/tests/types/src/types.test.tsx
@@ -9,17 +9,17 @@ import { z } from "@zod/mini";
 import { expectTypeOf } from "expect-type";
 import type { Array as YArray, Doc as YDoc } from "yjs";
 
-const io = createIO(
-    platformCloudflare({
-        authorize: {
-            secret: "",
-            user: z.object({
-                id: z.string(),
-            }),
-        },
-        context: ({ env, meta, state }) => ({ env, meta, state }),
-    }),
-);
+const platform = platformCloudflare({
+    authorize: {
+        secret: "",
+        user: z.object({
+            id: z.string(),
+        }),
+    },
+    context: ({ env, meta, state }) => ({ env, meta, state }),
+    crdt: yjs,
+});
+const io = createIO(platform);
 
 const router = io.router({
     sendMessage: io.procedure
@@ -34,6 +34,7 @@ const router = io.router({
 });
 
 const ioServer = io.server({
+    getInitialStorage: () => null,
     router,
     onRoomDeleted: async ({ context }) => {
         expectTypeOf<typeof context>().toEqualTypeOf<{


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fixed `getInitialStorage` not being required when `crdt` is provided.