### PR TITLE
feat(client): emit warning on missing crdt

### DIFF
--- a/.changeset/sad-coats-jam.md
+++ b/.changeset/sad-coats-jam.md
@@ -1,0 +1,29 @@
+---
+"@pluv/client": minor
+---
+
+TypeScript will now emit an error if `initialStorage` was provided to `createClient` while `createIO` was not provided a `crdt`.
+
+```ts
+import { createClient, infer } from "@pluv/client";
+import { yjs } from "@pluv/crdt-yjs";
+import { createIO } from "@pluv/io";
+import { platformCloudflare } from "@pluv/platform-cloudflare";
+
+const io = createIO(
+  // Assume no crdt was provided here
+  platformCloudflare({ /* ... */})
+);
+
+const ioServer = io.server();
+
+const types = infer((i) => ({ io: i<typeof ioServer> }));
+const client = createClient({
+  types,
+  // This will now emit a TypeScript error, because `crdt` was not provided to
+  // `createIO` above
+  initialStorage: yjs.doc((t) => ({
+    groceries: t.array<string>("groceries"),
+  })),
+});
+```

--- a/packages/client/src/PluvClient.ts
+++ b/packages/client/src/PluvClient.ts
@@ -35,7 +35,7 @@ export type PluvClientOptions<
     types: InferCallback<TIO>;
 } & (InferIOCrdtKind<TIO> extends NoopCrdtDocFactory
         ? { initialStorage?: "[ERROR]: Must provide crdt to createIO to use storage" }
-        : { initialStorage: TCrdt });
+        : { initialStorage?: TCrdt });
 
 export type CreateRoomOptions<
     TIO extends IOLike<any, any, any>,

--- a/packages/client/src/PluvClient.ts
+++ b/packages/client/src/PluvClient.ts
@@ -1,10 +1,5 @@
-import type {
-    AbstractCrdtDocFactory,
-    CrdtType,
-    InferStorage,
-    NoopCrdtDocFactory,
-} from "@pluv/crdt";
-import type { InputZodLike, IOLike, JsonObject } from "@pluv/types";
+import type { AbstractCrdtDocFactory, InferStorage, NoopCrdtDocFactory } from "@pluv/crdt";
+import type { InferIOCrdtKind, InputZodLike, IOLike, JsonObject } from "@pluv/types";
 import { MAX_PRESENCE_SIZE_BYTES } from "./constants";
 import type { InferCallback } from "./infer";
 import { PluvProcedure } from "./PluvProcedure";
@@ -25,11 +20,10 @@ import type { PluvClientLimits, PublicKey, WithMetadata } from "./types";
 export type PluvClientOptions<
     TIO extends IOLike<any, any, any>,
     TPresence extends Record<string, any>,
-    TCrdt extends AbstractCrdtDocFactory<any, any>,
+    TCrdt extends InferIOCrdtKind<TIO>,
     TMetadata extends JsonObject,
 > = RoomEndpoints<TIO, TMetadata> & {
     debug?: boolean;
-    initialStorage?: TCrdt;
     /**
      * @description Configurable limits defined for client-side validation. You should only set
      * this if you control the server and have changed the limits there.
@@ -39,7 +33,9 @@ export type PluvClientOptions<
     presence?: InputZodLike<TPresence>;
     publicKey?: PublicKey<TMetadata>;
     types: InferCallback<TIO>;
-};
+} & (InferIOCrdtKind<TIO> extends NoopCrdtDocFactory
+        ? { initialStorage?: "[ERROR]: Must provide crdt to createIO to use storage" }
+        : { initialStorage: TCrdt });
 
 export type CreateRoomOptions<
     TIO extends IOLike<any, any, any>,
@@ -64,7 +60,7 @@ export type EnterRoomParams<TMetadata extends JsonObject = {}> = keyof TMetadata
 export class PluvClient<
     TIO extends IOLike<any, any, any>,
     TPresence extends Record<string, any> = {},
-    TCrdt extends AbstractCrdtDocFactory<any, any> = NoopCrdtDocFactory,
+    TCrdt extends InferIOCrdtKind<TIO> = InferIOCrdtKind<TIO>,
     TMetadata extends JsonObject = {},
 > {
     public readonly metadata?: InputZodLike<TMetadata>;
@@ -104,7 +100,7 @@ export class PluvClient<
 
         this._authEndpoint = authEndpoint as AuthEndpoint<TMetadata>;
         this._debug = debug;
-        this._initialStorage = initialStorage;
+        this._initialStorage = initialStorage as TCrdt;
         this._limits = {
             presenceMaxSize: MAX_PRESENCE_SIZE_BYTES,
             ...limits,

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -1,12 +1,11 @@
-import type { AbstractCrdtDocFactory, NoopCrdtDocFactory } from "@pluv/crdt";
-import type { IOLike, JsonObject } from "@pluv/types";
+import type { InferIOCrdtKind, IOLike, JsonObject } from "@pluv/types";
 import type { PluvClientOptions } from "./PluvClient";
 import { PluvClient } from "./PluvClient";
 
 export const createClient = <
     TIO extends IOLike<any, any, any>,
     TPresence extends Record<string, any> = {},
-    TCrdt extends AbstractCrdtDocFactory<any, any> = NoopCrdtDocFactory,
+    TCrdt extends InferIOCrdtKind<TIO> = InferIOCrdtKind<TIO>,
     TMetadata extends JsonObject = {},
 >(
     options: PluvClientOptions<TIO, TPresence, TCrdt, TMetadata>,

--- a/packages/platform-cloudflare/src/platformCloudflare.ts
+++ b/packages/platform-cloudflare/src/platformCloudflare.ts
@@ -1,4 +1,4 @@
-import type { CrdtLibraryType } from "@pluv/crdt";
+import type { CrdtLibraryType, NoopCrdtDocFactory } from "@pluv/crdt";
 import type { CreateIOParams, InferInitContextType, PluvContext, PluvIOAuthorize } from "@pluv/io";
 import type { BaseUser, Id, IOAuthorize, Json } from "@pluv/types";
 import type { CloudflarePlatformConfig } from "./CloudflarePlatform";
@@ -10,7 +10,7 @@ export type PlatformCloudflareCreateIOParams<
     TMeta extends Record<string, Json> = {},
     TContext extends Record<string, any> = {},
     TUser extends BaseUser | null = null,
-    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
+    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
 > = Id<
     CloudflarePlatformConfig<TEnv, TMeta> &
         Omit<
@@ -40,7 +40,7 @@ export const platformCloudflare = <
     TMeta extends Record<string, Json> = {},
     TContext extends Record<string, any> = {},
     TUser extends BaseUser | null = null,
-    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
+    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
 >(
     config: PlatformCloudflareCreateIOParams<TEnv, TMeta, TContext, TUser, TCrdt> = {},
 ): CreateIOParams<

--- a/packages/platform-node/src/platformNode.ts
+++ b/packages/platform-node/src/platformNode.ts
@@ -1,4 +1,4 @@
-import type { CrdtLibraryType } from "@pluv/crdt";
+import type { CrdtLibraryType, NoopCrdtDocFactory } from "@pluv/crdt";
 import type { CreateIOParams, InferInitContextType, PluvContext, PluvIOAuthorize } from "@pluv/io";
 import type { BaseUser, Id, IOAuthorize, Json } from "@pluv/types";
 import type { NodePlatformConfig } from "./NodePlatform";
@@ -9,7 +9,7 @@ export type PlatformNodeCreateIOParams<
     TMeta extends Record<string, Json> = {},
     TContext extends Record<string, any> = {},
     TUser extends BaseUser | null = null,
-    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
+    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
 > = Id<
     NodePlatformConfig<TMeta> &
         Omit<
@@ -35,7 +35,7 @@ export const platformNode = <
     TMeta extends Record<string, Json> = {},
     TContext extends Record<string, any> = {},
     TUser extends BaseUser | null = null,
-    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
+    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
 >(
     config: PlatformNodeCreateIOParams<TMeta, TContext, TUser, TCrdt> = {},
 ): CreateIOParams<NodePlatform<IOAuthorize<TUser, TContext>, TMeta>, TContext, TUser, TCrdt> => {

--- a/packages/platform-pluv/src/platformPluv.ts
+++ b/packages/platform-pluv/src/platformPluv.ts
@@ -1,4 +1,4 @@
-import type { CrdtLibraryType } from "@pluv/crdt";
+import type { CrdtLibraryType, NoopCrdtDocFactory } from "@pluv/crdt";
 import type { CreateIOParams, InferInitContextType, PluvContext, PluvIOAuthorize } from "@pluv/io";
 import type { BaseUser, Id } from "@pluv/types";
 import type { PluvPlatformConfig } from "./PluvPlatform";
@@ -7,7 +7,7 @@ import { PluvPlatform } from "./PluvPlatform";
 export type PlatformPluvCreateIOParams<
     TContext extends Record<string, any> = {},
     TUser extends BaseUser = BaseUser,
-    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
+    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
 > = Id<
     PluvPlatformConfig &
         Omit<
@@ -22,7 +22,7 @@ export type PlatformPluvCreateIOParams<
 export const platformPluv = <
     TContext extends Record<string, any> = {},
     TUser extends BaseUser = BaseUser,
-    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
+    TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
 >(
     config: PlatformPluvCreateIOParams<TContext, TUser, TCrdt>,
 ): CreateIOParams<PluvPlatform<TContext, TUser>, TContext, TUser, TCrdt> => {

--- a/packages/react/src/createBundle.tsx
+++ b/packages/react/src/createBundle.tsx
@@ -11,15 +11,10 @@ import type {
     WebSocketConnection,
 } from "@pluv/client";
 import { MockedRoom } from "@pluv/client";
-import type {
-    AbstractCrdtDocFactory,
-    InferCrdtJson,
-    InferDoc,
-    InferStorage,
-    NoopCrdtDocFactory,
-} from "@pluv/crdt";
+import type { InferCrdtJson, InferDoc, InferStorage } from "@pluv/crdt";
 import type {
     Id,
+    InferIOCrdtKind,
     InferIOInput,
     InferIOOutput,
     IOEventMessage,
@@ -62,7 +57,7 @@ export type CreateBundleOptions<
     TIO extends IOLike<any, any, any>,
     TMetadata extends JsonObject = {},
     TPresence extends Record<string, any> = {},
-    TCrdt extends AbstractCrdtDocFactory<any, any> = NoopCrdtDocFactory,
+    TCrdt extends InferIOCrdtKind<TIO> = InferIOCrdtKind<TIO>,
     TEvents extends PluvRouterEventConfig<TIO, TPresence, InferStorage<TCrdt>> = {},
 > = {
     addons?: readonly PluvRoomAddon<TIO, TMetadata, TPresence, TCrdt>[];
@@ -73,7 +68,7 @@ export const createBundle = <
     TIO extends IOLike<any, any, any>,
     TMetadata extends JsonObject = {},
     TPresence extends Record<string, any> = {},
-    TCrdt extends AbstractCrdtDocFactory<any, any> = NoopCrdtDocFactory,
+    TCrdt extends InferIOCrdtKind<TIO> = InferIOCrdtKind<TIO>,
     TEvents extends PluvRouterEventConfig<TIO, TPresence, InferStorage<TCrdt>> = {},
 >(
     client: PluvClient<TIO, TPresence, TCrdt, TMetadata>,
@@ -178,7 +173,6 @@ export const createBundle = <
 
             useEffect(() => {
                 if (room.id === _room) return;
-
                 setRoom(createRoom());
             }, [_room, createRoom, room]);
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -13,11 +13,11 @@ import type {
     InferDoc,
     InferInitialStorageFn,
     InferStorage,
-    NoopCrdtDocFactory,
 } from "@pluv/crdt";
 import type {
     CrdtDocLike,
     Id,
+    InferIOCrdtKind,
     InferIOInput,
     InferIOOutput,
     IOEventMessage,
@@ -89,7 +89,7 @@ export interface CreateBundle<
     TIO extends IOLike<any, any, any>,
     TMetadata extends JsonObject,
     TPresence extends Record<string, any> = {},
-    TCrdt extends AbstractCrdtDocFactory<any, any> = NoopCrdtDocFactory,
+    TCrdt extends InferIOCrdtKind<TIO> = InferIOCrdtKind<TIO>,
     TEvents extends PluvRouterEventConfig<TIO, TPresence, InferStorage<TCrdt>> = {},
 > {
     // components

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -40,6 +40,7 @@ export type {
     InferEventsOutput,
     InferIOAuthorize,
     InferIOAuthorizeUser,
+    InferIOCrdtKind,
     InferIOInput,
     InferIOOutput,
     InputZodLike,

--- a/packages/types/src/pluv/crdt.ts
+++ b/packages/types/src/pluv/crdt.ts
@@ -5,8 +5,8 @@ export interface CrdtDocFactory<
     TStorage extends Record<string, CrdtType<any, any>>,
 > {
     _initialStorage: (builder: any) => TStorage;
-
     getEmpty(): CrdtDocLike<TDoc, TStorage>;
+    getFactory(initialStorage?: (builder: any) => TStorage): CrdtDocFactory<TDoc, TStorage>;
     getInitialized(initialStorage?: (builder: any) => TStorage): CrdtDocLike<TDoc, TStorage>;
 }
 

--- a/packages/types/src/pluv/shared.ts
+++ b/packages/types/src/pluv/shared.ts
@@ -150,6 +150,13 @@ export interface IOLike<
     };
 }
 
+export type InferIOCrdtKind<TIO extends IOLike<any, any, any>> =
+    TIO extends IOLike<any, infer ICrdt, any>
+        ? ICrdt extends CrdtLibraryType<infer IDoc>
+            ? IDoc
+            : never
+        : never;
+
 export type InferEventsInput<TEvents extends Record<string, ProcedureLike<any, any>>> = {
     [P in keyof TEvents]: TEvents[P] extends ProcedureLike<infer IInput, any> ? IInput : never;
 };

--- a/tests/e2e/src/pluv-io/loro/node.ts
+++ b/tests/e2e/src/pluv-io/loro/node.ts
@@ -2,7 +2,7 @@ import { createClient, infer } from "@pluv/client";
 import { loro } from "@pluv/crdt-loro";
 import { createBundle } from "@pluv/react";
 import { z } from "zod";
-import type { ioServer } from "../../server/yjs/node";
+import type { ioServer } from "../../server/loro/node";
 
 const types = infer((i) => ({ io: i<typeof ioServer> }));
 const client = createClient({

--- a/tests/types/src/no-crdt.test.tsx
+++ b/tests/types/src/no-crdt.test.tsx
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { infer as clientInfer, createClient } from "@pluv/client";
+import { yjs } from "@pluv/crdt-yjs";
+import { createIO } from "@pluv/io";
+import { platformCloudflare } from "@pluv/platform-cloudflare";
+import { z } from "@zod/mini";
+
+const io = createIO(
+    platformCloudflare({
+        authorize: {
+            secret: "",
+            user: z.object({
+                id: z.string(),
+            }),
+        },
+    }),
+);
+
+const ioServer = io.server({
+    // @ts-expect-error
+    getInitialStorage: () => null,
+});
+
+const types = clientInfer((i) => ({ io: i<typeof ioServer> }));
+createClient({
+    types,
+    // @ts-expect-error
+    initialStorage: yjs.doc((t) => ({
+        messages: t.array<string>("messages"),
+    })),
+});

--- a/tests/types/src/types.test.tsx
+++ b/tests/types/src/types.test.tsx
@@ -9,17 +9,18 @@ import { z } from "@zod/mini";
 import { expectTypeOf } from "expect-type";
 import type { Array as YArray, Doc as YDoc } from "yjs";
 
-const platform = platformCloudflare({
-    authorize: {
-        secret: "",
-        user: z.object({
-            id: z.string(),
-        }),
-    },
-    context: ({ env, meta, state }) => ({ env, meta, state }),
-    crdt: yjs,
-});
-const io = createIO(platform);
+const io = createIO(
+    platformCloudflare({
+        authorize: {
+            secret: "",
+            user: z.object({
+                id: z.string(),
+            }),
+        },
+        context: ({ env, meta, state }) => ({ env, meta, state }),
+        crdt: yjs,
+    }),
+);
 
 const router = io.router({
     sendMessage: io.procedure


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Emit TypeScript error in `createClient` if `crdt` is incompatible on `createIO`.