### PR TITLE
fix(io): pluv server args

### DIFF
--- a/.changeset/tasty-ghosts-smoke.md
+++ b/.changeset/tasty-ghosts-smoke.md
@@ -1,0 +1,5 @@
+---
+"@pluv/io": patch
+---
+
+Fixed `PluvIO.server` not requiring input parameters (i.e. was optional) when `createIO` specified `crdt`.

--- a/packages/types/src/general.ts
+++ b/packages/types/src/general.ts
@@ -1,5 +1,11 @@
 export type Constructable = { new (...args: any[]): any };
 
+export type HasRequiredProperty<T> = {
+    [K in keyof T]-?: {} extends Pick<T, K> ? never : K;
+}[keyof T] extends never
+    ? false
+    : true;
+
 export type Maybe<T> = T | Nil;
 export type MaybePromise<T> = Promise<T> | T;
 export type MaybeReadonlyArray<T> = T[] | readonly T[];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,6 +2,7 @@ export type {
     Constructable,
     DeepPartial,
     DeepWriteable,
+    HasRequiredProperty,
     Id,
     Json,
     JsonObject,

--- a/tests/types/src/has-crdt.test.tsx
+++ b/tests/types/src/has-crdt.test.tsx
@@ -4,17 +4,21 @@ import { yjs } from "@pluv/crdt-yjs";
 import { createIO } from "@pluv/io";
 import { platformCloudflare } from "@pluv/platform-cloudflare";
 
-const io = createIO(platformCloudflare({}));
+const io = createIO(platformCloudflare({ crdt: yjs }));
 
-const ioServer = io.server({
-    // @ts-expect-error
+// @ts-expect-error
+const ioServer = io.server();
+// @ts-expect-error
+io.server({});
+
+// Should not error. getInitialStorage is required.
+io.server({
     getInitialStorage: () => null,
 });
 
 const types = clientInfer((i) => ({ io: i<typeof ioServer> }));
 createClient({
     types,
-    // @ts-expect-error
     initialStorage: yjs.doc((t) => ({
         messages: t.array<string>("messages"),
     })),


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fixed `PluvIO.server` not requiring input parameters (i.e. was optional) when `createIO` specified `crdt`.