### PR TITLE
fix(platform-pluv): fix workerd crash

### DIFF
--- a/.changeset/fix-platform-pluv-workers-crypto.md
+++ b/.changeset/fix-platform-pluv-workers-crypto.md
@@ -1,0 +1,7 @@
+---
+"@pluv/platform-pluv": patch
+---
+
+Fix Cloudflare Workers / workerd startup crash caused by a top-level `createRequire(import.meta.url)` injected when bundling a Node `require("node:crypto")` fallback.
+
+`getCrypto` now uses `globalThis.crypto` only (available on modern Node, browsers, and Workers). This removes the Node `require` path so the published ESM build no longer initializes `createRequire` on import.

--- a/packages/platform-pluv/src/shared/createHmac.ts
+++ b/packages/platform-pluv/src/shared/createHmac.ts
@@ -1,4 +1,3 @@
-import type { webcrypto } from "crypto";
 import { getCrypto } from "./getCrypto";
 
 export interface CreateHmacParams {
@@ -21,7 +20,7 @@ export const createHmac = async (params: CreateHmacParams): Promise<CreateHmacRe
 
     const crypto = getCrypto();
 
-    const algorithm: webcrypto.HmacImportParams = { name: "HMAC", hash: { name: "SHA-256" } };
+    const algorithm: HmacImportParams = { name: "HMAC", hash: { name: "SHA-256" } };
     const extractable = false;
 
     const key = await crypto.subtle.importKey("raw", keyBytes, algorithm, extractable, [

--- a/packages/platform-pluv/src/shared/getCrypto.ts
+++ b/packages/platform-pluv/src/shared/getCrypto.ts
@@ -1,17 +1,7 @@
-import type { webcrypto } from "crypto";
-
-export const getCrypto = (): webcrypto.Crypto => {
-    if (typeof crypto !== "undefined") {
-        // In a browser or Web Worker (including Cloudflare Workers)
-        return crypto;
+export const getCrypto = (): Crypto => {
+    if (typeof globalThis.crypto !== "undefined") {
+        return globalThis.crypto;
     }
 
-    if (typeof require === "function") {
-        // In Node.js
-        // Node 15+ supports `crypto.webcrypto`
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        return require("node:crypto").webcrypto as webcrypto.Crypto;
-    }
-
-    throw new Error("Missing crypto module");
+    throw new Error("Missing Web Crypto API (globalThis.crypto)");
 };


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/master/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fix Cloudflare Workers / workerd startup crash caused by a top-level `createRequire(import.meta.url)` injected when bundling a Node `require("node:crypto")` fallback.

`getCrypto` now uses `globalThis.crypto` only (available on modern Node, browsers, and Workers). This removes the Node `require` path so the published ESM build no longer initializes `createRequire` on import.