### PR TITLE
fix(client): return null from getStorage while unavailable

### DIFF
--- a/.changeset/storage-teardown-notifies-consumers.md
+++ b/.changeset/storage-teardown-notifies-consumers.md
@@ -1,0 +1,12 @@
+---
+"@pluv/client": minor
+"@pluv/react": minor
+---
+
+Stop handing out storage shared-types while storage is unavailable.
+
+- `room.getStorage(...)` now returns `null` until storage is loaded. It previously returned a writable shared-type whose updates were discarded without an error, so consumers had to gate on the connection state themselves.
+- `useStorage` now returns `[null, null] | [data, sharedType]` rather than two independently nullable values, so one null check narrows both. Exports the new `UseStorageResult` type.
+- `useStorage` and `useDoc` now update when storage becomes unavailable, not only when it loads.
+- `room.disconnect()` now reports storage as `unavailable` and stops observing the doc it destroyed.
+- Storage updates that cannot be sent are now logged in debug mode instead of being dropped silently.

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -470,10 +470,8 @@ export class PluvRoom<
         this._updateState((oldState) => {
             oldState.authorization.token = null;
             oldState.connection.state = ConnectionState.Closed;
-            oldState.storage.state =
-                oldState.storage.state === StorageState.Synced
-                    ? StorageState.Offline
-                    : StorageState.Unavailable;
+            // Unlike `_onClose`, this destroys the doc below, so storage is gone.
+            oldState.storage.state = StorageState.Unavailable;
             oldState.webSocket = null;
 
             return oldState;
@@ -481,6 +479,9 @@ export class PluvRoom<
 
         await this._storageStore.destroy();
         this._crdtManager.destroy();
+
+        // `destroy` swaps in a new doc, so stop observing the destroyed one.
+        this._observeCrdt();
         this._stateNotifier.subjects["my-presence"].next(null);
     }
 
@@ -512,6 +513,10 @@ export class PluvRoom<
     public getStorage = <TKey extends keyof InferStorage<TCrdt>>(
         type: TKey,
     ): InferStorage<TCrdt>[TKey] | null => {
+        // Updates aren't delivered until storage loads, so don't hand out a writable
+        // shared-type that silently discards writes.
+        if (!this.getStorageLoaded()) return null;
+
         const sharedType = this._crdtManager.get(type);
 
         if (typeof sharedType === "undefined") return null;
@@ -1095,13 +1100,14 @@ export class PluvRoom<
 
         const encodedState = this._crdtManager.doc.getEncodedState();
 
-        this._emitSharedTypes();
-        this._observeCrdt();
+        // Must precede `_emitSharedTypes`, since `getStorage` returns null until loaded.
         this._updateState((oldState) => {
             oldState.storage.state = StorageState.Synced;
 
             return oldState;
         });
+        this._emitSharedTypes();
+        this._observeCrdt();
         this._stateNotifier.subjects["storage-loaded"].next(true);
 
         this._sendMessage({
@@ -1247,9 +1253,16 @@ export class PluvRoom<
 
             this._addToStorageStore(event.update);
 
-            if (!this._state.webSocket) return;
-            if (!this._state.connection.id) return;
-            if (this._state.webSocket.readyState !== WebSocket.OPEN) return;
+            const canSend =
+                !!this._state.webSocket &&
+                !!this._state.connection.id &&
+                this._state.webSocket.readyState === WebSocket.OPEN;
+
+            if (!canSend) {
+                this._logDebug("Dropped a storage update: storage is not syncing");
+
+                return;
+            }
 
             this._sendMessage({
                 type: "$updateStorage",

--- a/packages/react/src/createBundle.tsx
+++ b/packages/react/src/createBundle.tsx
@@ -21,6 +21,7 @@ import type {
     IOLike,
     JsonObject,
     RoomLike,
+    StorageState,
     UpdateMyPresenceAction,
 } from "@pluv/types";
 import fastDeepEqual from "fast-deep-equal";
@@ -51,6 +52,7 @@ import type {
     PluvProviderProps,
     PluvRoomProviderProps,
     SubscriptionHookOptions,
+    UseStorageResult,
 } from "./types";
 
 export type CreateBundleOptions<
@@ -354,7 +356,19 @@ export const createBundle = <
         const room = useRoom();
 
         const subscribe = useCallback(
-            (onStoreChange: () => void) => room.subscribe.storageLoaded(onStoreChange),
+            (onStoreChange: () => void) => {
+                // Storage teardown only surfaces on the connection state, so watch both.
+                const unsubscribes = [
+                    room.subscribe.storageLoaded(onStoreChange),
+                    room.subscribe.connection(onStoreChange),
+                ];
+
+                return () => {
+                    unsubscribes.forEach((unsubscribe) => {
+                        unsubscribe();
+                    });
+                };
+            },
             [room],
         );
 
@@ -541,17 +555,31 @@ export const createBundle = <
         key: TKey,
         selector = identity as (data: InferCrdtJson<InferStorage<TCrdt>[TKey]>) => TData,
         hookOptions?: SubscriptionHookOptions<TData | null>,
-    ): [data: TData | null, sharedType: InferStorage<TCrdt>[TKey] | null] => {
+    ): UseStorageResult<TData, InferStorage<TCrdt>[TKey]> => {
         const room = useRoom();
         const rerender = useRerender();
 
         useEffect(() => {
-            const unsubscribe = room.subscribe.storageLoaded(() => {
-                rerender();
-            });
+            let storageState: StorageState | null = null;
+
+            const unsubscribes = [
+                room.subscribe.storageLoaded(() => {
+                    rerender();
+                }),
+                // `storageLoaded` never fires on teardown, so watch the storage state too.
+                room.subscribe.connection(({ storage }) => {
+                    if (storage.state === storageState) return;
+
+                    storageState = storage.state;
+
+                    rerender();
+                }),
+            ];
 
             return () => {
-                unsubscribe();
+                unsubscribes.forEach((unsubscribe) => {
+                    unsubscribe();
+                });
             };
         }, [rerender, room]);
 
@@ -580,6 +608,8 @@ export const createBundle = <
         );
 
         const sharedType = room.getStorage(key) ?? null;
+
+        if (data === null || sharedType === null) return [null, null];
 
         return [data, sharedType];
     };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -6,4 +6,5 @@ export type {
     PluvProviderProps,
     PluvRoomProviderProps,
     SubscriptionHookOptions,
+    UseStorageResult,
 } from "./types";

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -33,6 +33,13 @@ export interface PluvProviderProps {
     children?: ReactNode;
 }
 
+/**
+ * Storage is all-or-nothing, so a union (not two nullable slots) lets one check narrow both.
+ */
+export type UseStorageResult<TData extends unknown, TSharedType extends unknown> =
+    | [data: null, sharedType: null]
+    | [data: TData, sharedType: TSharedType];
+
 type BaseRoomProviderProps<
     TPresence extends Record<string, any>,
     TCrdt extends AbstractCrdtDocFactory<any, any>,
@@ -140,7 +147,7 @@ export interface CreateBundle<
         key: TKey,
         selector?: (data: InferCrdtJson<InferStorage<TCrdt>[TKey]>) => TData,
         options?: SubscriptionHookOptions<TData | null>,
-    ) => [data: TData | null, sharedType: InferStorage<TCrdt>[TKey] | null];
+    ) => UseStorageResult<TData, InferStorage<TCrdt>[TKey]>;
     useTransact: () => (fn: (storage: InferStorage<TCrdt>) => void, origin?: string) => void;
     useUndo: () => () => void;
 }

--- a/tests/types/src/types.test.tsx
+++ b/tests/types/src/types.test.tsx
@@ -166,6 +166,19 @@ const storageMessages = useStorage("messages");
 expectTypeOf(storageMessages[0]).toEqualTypeOf<string[] | null>();
 expectTypeOf(storageMessages[1]).toEqualTypeOf<yjs.YjsType<YArray<string>, string[]> | null>();
 
+expectTypeOf(storageMessages).toEqualTypeOf<
+    | [data: null, sharedType: null]
+    | [data: string[], sharedType: yjs.YjsType<YArray<string>, string[]>]
+>();
+
+const [storageMessagesData, storageMessagesSharedType] = storageMessages;
+
+if (!!storageMessagesSharedType) {
+    expectTypeOf(storageMessagesData).toEqualTypeOf<string[]>();
+} else {
+    expectTypeOf(storageMessagesData).toEqualTypeOf<null>();
+}
+
 expectTypeOf(useDoc()).toEqualTypeOf<
     CrdtDocLike<
         YDoc,


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/main/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

- `room.getStorage(...)` now returns `null` until storage is loaded. It previously returned a writable shared-type whose updates were discarded without an error, so consumers had to gate on the connection state themselves.
- `useStorage` now returns `[null, null] | [data, sharedType]` rather than two independently nullable values, so one null check narrows both. Exports the new `UseStorageResult` type.
- `useStorage` and `useDoc` now update when storage becomes unavailable, not only when it loads.
- `room.disconnect()` now reports storage as `unavailable` and stops observing the doc it destroyed.
- Storage updates that cannot be sent are now logged in debug mode instead of being dropped silently.