### PR TITLE
fix: avoid stale Yjs docs and racing storage writes

### DIFF
--- a/.changeset/fix-stale-yjs-doc-and-storage-races.md
+++ b/.changeset/fix-stale-yjs-doc-and-storage-races.md
@@ -1,0 +1,11 @@
+---
+"@pluv/crdt-yjs": patch
+"@pluv/io": patch
+"@pluv/persistence-cloudflare-transactional-storage": patch
+---
+
+Avoid stale Yjs docs and racing storage writes.
+
+- `PluvYjsProvider.doc` now reads the room's current doc instead of snapshotting it in the constructor, so the provider stays valid after destroy/re-init.
+- `$updateStorage` awaits `setStorageState` before continuing, so concurrent updates cannot persist an older snapshot.
+- Cloudflare transactional storage no longer sets `allowConcurrency: true` on storage puts.

--- a/packages/crdt-yjs/src/provider/PluvYjsProvider.ts
+++ b/packages/crdt-yjs/src/provider/PluvYjsProvider.ts
@@ -43,12 +43,16 @@ export class PluvYjsProvider<
     synced: (state: boolean) => void;
 }> {
     public readonly awareness: PluvYjsAwareness<TIO, TPresence, TStorage, TEvents, TField>;
-    public readonly doc: YDoc;
 
     private readonly _room: RoomLike<TIO, YDoc, TPresence, TStorage, TEvents>;
     private readonly _unsubscribe: () => void;
 
     private _synced: boolean = false;
+
+    // Always read the live doc. The room may replace it after destroy/re-init.
+    public get doc(): YDoc {
+        return this._room.getDoc().value;
+    }
 
     constructor(params: PluvYjsProviderParams<TIO, TPresence, TStorage, TEvents, TField>) {
         super();
@@ -56,8 +60,6 @@ export class PluvYjsProvider<
         const { presenceField, room } = params;
 
         this.awareness = awareness({ presenceField, room });
-        this.doc = room.getDoc().value;
-
         this._room = room;
 
         const subscriptions = [

--- a/packages/io/src/PluvServer.ts
+++ b/packages/io/src/PluvServer.ts
@@ -317,7 +317,7 @@ export class PluvServer<
                     },
                 };
             }),
-            $updateStorage: this._procedure.broadcast((data, { context, doc, platform, room }) => {
+            $updateStorage: this._procedure.broadcast(async (data, { context, doc, platform, room }) => {
                 const origin = (data as any)?.origin as Maybe<string>;
                 const update: string | null = (data as any)?.update ?? null;
 
@@ -338,13 +338,13 @@ export class PluvServer<
                     `);
                 }
 
-                platform.persistence.setStorageState(room, encodedState).then(() => {
-                    listeners.onStorageUpdated({
-                        context,
-                        encodedState,
-                        platform,
-                        room,
-                    });
+                await platform.persistence.setStorageState(room, encodedState);
+
+                listeners.onStorageUpdated({
+                    context,
+                    encodedState,
+                    platform,
+                    room,
                 });
 
                 return { $storageUpdated: { state: encodedState } };

--- a/packages/io/src/PluvServer.ts
+++ b/packages/io/src/PluvServer.ts
@@ -317,38 +317,40 @@ export class PluvServer<
                     },
                 };
             }),
-            $updateStorage: this._procedure.broadcast(async (data, { context, doc, platform, room }) => {
-                const origin = (data as any)?.origin as Maybe<string>;
-                const update: string | null = (data as any)?.update ?? null;
+            $updateStorage: this._procedure.broadcast(
+                async (data, { context, doc, platform, room }) => {
+                    const origin = (data as any)?.origin as Maybe<string>;
+                    const update: string | null = (data as any)?.update ?? null;
 
-                if (origin === "$initialized" && Object.keys(doc.toJson()).length) return {};
+                    if (origin === "$initialized" && Object.keys(doc.toJson()).length) return {};
 
-                const updated = update === null ? doc : doc.applyEncodedState({ update });
-                const encodedState = updated.getEncodedState();
-                const storageSize = new TextEncoder().encode(encodedState).length;
+                    const updated = update === null ? doc : doc.applyEncodedState({ update });
+                    const encodedState = updated.getEncodedState();
+                    const storageSize = new TextEncoder().encode(encodedState).length;
 
-                if (
-                    !!this._config.limits.storageMaxSize &&
-                    storageSize > this._config.limits.storageMaxSize
-                ) {
-                    throw new Error(oneLine`
+                    if (
+                        !!this._config.limits.storageMaxSize &&
+                        storageSize > this._config.limits.storageMaxSize
+                    ) {
+                        throw new Error(oneLine`
                         Large Storage. Storage must be at most
                         ${this._config.limits.storageMaxSize.toLocaleString()} bytes.
                         Current size: ${storageSize.toLocaleString()} bytes
                     `);
-                }
+                    }
 
-                await platform.persistence.setStorageState(room, encodedState);
+                    await platform.persistence.setStorageState(room, encodedState);
 
-                listeners.onStorageUpdated({
-                    context,
-                    encodedState,
-                    platform,
-                    room,
-                });
+                    listeners.onStorageUpdated({
+                        context,
+                        encodedState,
+                        platform,
+                        room,
+                    });
 
-                return { $storageUpdated: { state: encodedState } };
-            }),
+                    return { $storageUpdated: { state: encodedState } };
+                },
+            ),
         });
     }
 

--- a/packages/persistence-cloudflare-transactional-storage/src/PersistenceCloudflareTransactionalStorage.ts
+++ b/packages/persistence-cloudflare-transactional-storage/src/PersistenceCloudflareTransactionalStorage.ts
@@ -328,9 +328,7 @@ export class PersistenceCloudflareTransactionalStorage extends AbstractPersisten
         await this._initialized;
 
         if (this._mode === "kv") {
-            await this._state.storage.put(this._getStorageKey(room), state, {
-                allowConcurrency: true,
-            });
+            await this._state.storage.put(this._getStorageKey(room), state);
             return;
         }
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/main/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

- `PluvYjsProvider.doc` now reads the room's current doc instead of snapshotting it in the constructor, so the provider stays valid after destroy/re-init.
- `$updateStorage` awaits `setStorageState` before continuing, so concurrent updates cannot persist an older snapshot.
- Cloudflare transactional storage no longer sets `allowConcurrency: true` on storage puts.
