### PR TITLE
fix(io): emit onStorageDestroyed for rooms loaded from getInitialStorage

### DIFF
--- a/.changeset/fix-storage-destroyed-after-initial-storage.md
+++ b/.changeset/fix-storage-destroyed-after-initial-storage.md
@@ -1,0 +1,7 @@
+---
+"@pluv/io": patch
+---
+
+Fix `onStorageDestroyed` never firing for rooms hydrated from `getInitialStorage`.
+
+Storage loaded from `getInitialStorage` was not marked as initialized, and the loaded content made `_wasDocEmptyOnInit` false, which permanently prevented the room from marking storage as initialized later. `onStorageDestroyed` was gated on that flag, so rooms that cold-started with content from an external store could never persist again and the external store kept its original snapshot.

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -672,6 +672,11 @@ export class IORoom<
 
             if (!!loadedState && !this._docFactory.isEmpty(loadedState)) {
                 doc.applyEncodedState({ update: loadedState });
+
+                // Storage loaded from getInitialStorage is already initialized. Without this,
+                // _wasDocEmptyOnInit is false and onStorageDestroyed can never fire again, so
+                // the external store keeps whatever snapshot it had.
+                this._storageInitializedViaSession = true;
             }
         }
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/main/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fix `onStorageDestroyed` never firing for rooms hydrated from `getInitialStorage`.

Storage loaded from `getInitialStorage` was not marked as initialized, and the loaded content made `_wasDocEmptyOnInit` false, which permanently prevented the room from marking storage as initialized later. `onStorageDestroyed` was gated on that flag, so rooms that cold-started with content from an external store could never persist again and the external store kept its original snapshot.

