### PR TITLE
fix: storage clearing on teardown

### DIFF
--- a/.changeset/atomic-room-teardown.md
+++ b/.changeset/atomic-room-teardown.md
@@ -1,0 +1,14 @@
+---
+"@pluv/crdt-loro": minor
+"@pluv/crdt-yjs": minor
+"@pluv/crdt": minor
+"@pluv/types": minor
+"@pluv/io": patch
+---
+
+Prevent room teardown from persisting an empty document over saved storage.
+
+- `IORoom` teardown is now atomic. A second teardown joins the one already in flight instead of re-running it and emitting `onStorageDestroyed` with a document that was already cleared.
+- `IORoom.register` now waits for an in-flight teardown, so a connection arriving mid-teardown re-initializes from storage instead of binding to the cleared document.
+- Added `isDirty()` to `CrdtDocLike`, implemented for the yjs, loro and noop documents. It reports whether a document has ever been written to, and teardown uses it to skip `onStorageDestroyed` for a document that never was. It is not the inverse of `isEmpty()`: deleting all content leaves a document dirty, so emptied storage still persists.
+- Breaking for external `CrdtDocLike` implementations: `isDirty()` is a new required member.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,33 @@
+name: Unit Tests
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        types: [opened, synchronize]
+
+jobs:
+    test:
+        name: Test
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [lts/*]
+
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v7
+
+            - name: Setup Node.js 24.x
+              uses: actions/setup-node@v7
+              with:
+                  node-version: 24.x
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v6.1.0
+
+            - name: Install Dependencies
+              run: pnpm install
+
+            - name: Test
+              run: pnpm test:unit

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "test": "turbo run test",
         "test:e2e": "turbo run test --filter=@pluv-tests/e2e...",
         "test:types": "turbo run test --filter=@pluv-tests/types...",
+        "test:unit": "turbo run test --filter=@pluv-tests/unit...",
         "typecheck": "turbo run typecheck",
         "turbo": "turbo",
         "version-packages": "changeset version"

--- a/packages/crdt-loro/src/doc/CrdtLoroDoc.ts
+++ b/packages/crdt-loro/src/doc/CrdtLoroDoc.ts
@@ -151,6 +151,10 @@ export class CrdtLoroDoc<
         }, {} as InferCrdtJson<TStorage>);
     }
 
+    public isDirty(): boolean {
+        return !!this.value.oplogFrontiers().length;
+    }
+
     public isEmpty(): boolean {
         const serialized = this.value.toJSON();
 

--- a/packages/crdt-yjs/src/doc/CrdtYjsDoc.ts
+++ b/packages/crdt-yjs/src/doc/CrdtYjsDoc.ts
@@ -116,6 +116,11 @@ export class CrdtYjsDoc<TStorage extends Record<string, YjsType<any, any>>> impl
         return fromUint8Array(encodeStateAsUpdate(this.value));
     }
 
+    public isDirty(): boolean {
+        // Unlike `share`, the struct store stays empty until an operation is actually written.
+        return !!this.value.store.clients.size;
+    }
+
     public isEmpty(): boolean {
         return !this.value.share.size;
     }

--- a/packages/crdt/src/NoopCrdtDoc.ts
+++ b/packages/crdt/src/NoopCrdtDoc.ts
@@ -38,6 +38,10 @@ export class NoopCrdtDoc implements CrdtDocLike<any, any> {
         return "";
     }
 
+    public isDirty(): boolean {
+        return false;
+    }
+
     public isEmpty(): boolean {
         return true;
     }

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -127,6 +127,7 @@ export class IORoom<
 
     private _doc: Promise<CrdtDocLike<any, any>>;
     private _lastGarbageCollectMs: number = -1 * (GARBAGE_COLLECT_INTERVAL_MS + 1);
+    private _teardown: Promise<void> | null = null;
     private _uninitialize: Promise<() => Promise<void>> | null = null;
 
     private readonly _authorize: TAuthorize = null as TAuthorize;
@@ -368,6 +369,10 @@ export class IORoom<
         const sessionExists = typeof sessionId === "string" && this._sessions.has(sessionId);
 
         if (sessionExists) return;
+
+        // Joining an in-flight teardown lets the room re-initialize from storage below, rather
+        // than binding this connection to the doc that teardown discards.
+        if (this._teardown) await this._teardown;
 
         if (!(await this._initialized)) {
             this._initialize();
@@ -816,45 +821,72 @@ export class IORoom<
             // Track if doc was empty when room was first initialized
             this._wasDocEmptyOnInit = doc.isEmpty();
 
-            const uninitialize = async () => {
-                this._platform.pubSub.unsubscribe(pubSubId);
+            const uninitialize = async (): Promise<void> => {
+                // Teardown clears the doc partway through, so re-entering would persist that
+                // cleared doc over the room's real content.
+                if (this._teardown) return this._teardown;
 
-                const [resolvedDoc, context] = await Promise.all([this._doc, this._getContext()]);
-                const encodedState = resolvedDoc.getEncodedState();
+                this._teardown = (async () => {
+                    this._platform.pubSub.unsubscribe(pubSubId);
 
-                resolvedDoc.destroy();
-                this._doc = Promise.resolve(this._docFactory.getEmpty());
+                    const [resolvedDoc, context] = await Promise.all([
+                        this._doc,
+                        this._getContext(),
+                    ]);
+                    const encodedState = resolvedDoc.getEncodedState();
 
-                // Always emit onRoomDestroyed
-                await Promise.resolve(
-                    this._listeners.onRoomDestroyed({
-                        ...("_meta" in this._platform && !!this._platform._meta
-                            ? { _meta: this._platform._meta }
-                            : {}),
-                        context,
-                        platform: this._platform,
-                        room: this.id,
-                    }),
-                );
+                    // This room has held content, so an unwritten doc here was cleared by a
+                    // teardown rather than by the user.
+                    const shouldDestroyStorage =
+                        this._storageInitializedViaSession && resolvedDoc.isDirty();
 
-                // Only emit onStorageDestroyed if storage was initialized via initializeSession
-                if (this._storageInitializedViaSession) {
+                    if (this._storageInitializedViaSession && !shouldDestroyStorage) {
+                        this._logDebug(
+                            colors.blue(
+                                `Refusing to persist an unwritten document for room: ${this.id}`,
+                            ),
+                        );
+                    }
+
+                    this._storageInitializedViaSession = false;
+
+                    resolvedDoc.destroy();
+                    this._doc = Promise.resolve(this._docFactory.getEmpty());
+
+                    // Always emit onRoomDestroyed
                     await Promise.resolve(
-                        this._listeners.onStorageDestroyed({
+                        this._listeners.onRoomDestroyed({
                             ...("_meta" in this._platform && !!this._platform._meta
                                 ? { _meta: this._platform._meta }
                                 : {}),
                             context,
-                            encodedState,
                             platform: this._platform,
                             room: this.id,
                         }),
                     );
 
-                    this._storageInitializedViaSession = false;
-                }
+                    if (shouldDestroyStorage) {
+                        await Promise.resolve(
+                            this._listeners.onStorageDestroyed({
+                                ...("_meta" in this._platform && !!this._platform._meta
+                                    ? { _meta: this._platform._meta }
+                                    : {}),
+                                context,
+                                encodedState,
+                                platform: this._platform,
+                                room: this.id,
+                            }),
+                        );
+                    }
 
-                this._uninitialize = null;
+                    this._uninitialize = null;
+                })();
+
+                try {
+                    await this._teardown;
+                } finally {
+                    this._teardown = null;
+                }
             };
 
             return { doc, uninitialize };

--- a/packages/types/src/pluv/crdt.ts
+++ b/packages/types/src/pluv/crdt.ts
@@ -70,6 +70,11 @@ export interface CrdtDocLike<
     get(key?: undefined): TStorage;
     get<TKey extends keyof TStorage>(key: TKey): TStorage[TKey];
     getEncodedState(): string;
+    /**
+     * @description Whether the document has ever received an operation. Not the inverse of
+     * `isEmpty()`: a document whose content was deleted is still dirty.
+     */
+    isDirty(): boolean;
     isEmpty(): boolean;
     rebuildStorage(reference: TStorage): this;
     redo(): this;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -846,6 +846,43 @@ importers:
         specifier: ^4.129.0
         version: 4.129.0(@cloudflare/workers-types@5.20260906.1)
 
+  tests/unit:
+    dependencies:
+      '@pluv/crdt':
+        specifier: workspace:^
+        version: link:../../packages/crdt
+      '@pluv/crdt-loro':
+        specifier: workspace:^
+        version: link:../../packages/crdt-loro
+      '@pluv/crdt-yjs':
+        specifier: workspace:^
+        version: link:../../packages/crdt-yjs
+      '@pluv/io':
+        specifier: workspace:^
+        version: link:../../packages/io
+      '@pluv/types':
+        specifier: workspace:^
+        version: link:../../packages/types
+      loro-crdt:
+        specifier: ^1.16.0
+        version: 1.16.0
+      yjs:
+        specifier: ^13.6.32
+        version: 13.6.32
+    devDependencies:
+      '@pluv/tsconfig':
+        specifier: workspace:^
+        version: link:../../packages/tsconfig
+      '@types/node':
+        specifier: ^26.4.1
+        version: 26.4.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@26.4.1)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
+
 packages:
 
   '@babel/code-frame@7.27.1':
@@ -3675,6 +3712,9 @@ packages:
   '@types/better-sqlite3@9.6.0':
     resolution: {integrity: sha512-ZEEwBSgMu7GYJOynoagg5X9JbxfL6dTJDsgViJIqh67jV44kyOr9RXfmFjLK5rzC4MWssP06t9hu/JwGDnUbCg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/common-tags@1.8.4':
     resolution: {integrity: sha512-S+1hLDJPjWNDhcGxsxEbepzaxWqURP/o+3cP4aa2w7yBXgdcmKGQtZzP8JbyfOd0m+33nh+8+kvxYE2UJtBDkg==}
 
@@ -3683,6 +3723,9 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -3875,6 +3918,35 @@ packages:
         optional: true
       oxc-transform-react:
         optional: true
+
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   '@yuku-analyzer/binding-android-arm64@0.9.4':
     resolution: {integrity: sha512-ViV7rntyKeSeDQL29jKRjHRdJNFQLfpNGbovAvbABeZZyrAejhzxc6nRDQmMP0bVhMntmS5F/63RmI3h54u1Hg==}
@@ -4132,6 +4204,10 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -4219,6 +4295,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -6206,6 +6286,9 @@ packages:
     resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -6251,8 +6334,14 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -6335,6 +6424,9 @@ packages:
   tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.3.1:
     resolution: {integrity: sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==}
     engines: {node: '>=18'}
@@ -6346,6 +6438,10 @@ packages:
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -6611,6 +6707,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -6630,6 +6767,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wonka@6.3.6:
@@ -9225,6 +9367,11 @@ snapshots:
     dependencies:
       '@types/node': 26.4.1
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/common-tags@1.8.4': {}
 
   '@types/cors@2.8.19':
@@ -9234,6 +9381,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -9350,6 +9499,47 @@ snapshots:
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
+
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.11': {}
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@yuku-analyzer/binding-android-arm64@0.9.4':
     optional: true
@@ -9511,6 +9701,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  assertion-error@2.0.1: {}
+
   astring@1.9.0: {}
 
   async@3.2.6: {}
@@ -9598,6 +9790,8 @@ snapshots:
   caniuse-lite@1.0.30001810: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@2.4.2:
     dependencies:
@@ -11964,6 +12158,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.5
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   sisteransi@1.0.5: {}
@@ -12009,7 +12205,11 @@ snapshots:
 
   srvx@0.11.22: {}
 
+  stackback@0.0.2: {}
+
   standard-as-callback@2.1.0: {}
+
+  std-env@4.2.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -12081,6 +12281,8 @@ snapshots:
 
   tiny-invariant@1.3.1: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.3.1: {}
 
   tinyglobby@0.2.17:
@@ -12089,6 +12291,8 @@ snapshots:
       picomatch: 4.0.7
 
   tinypool@2.1.0: {}
+
+  tinyrainbow@3.1.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -12334,6 +12538,33 @@ snapshots:
     optionalDependencies:
       vite: 8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
 
+  vitest@4.1.11(@types/node@26.4.1)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.1
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.4.1
+    transitivePeerDependencies:
+      - msw
+
   w3c-keyname@2.2.8: {}
 
   wcwidth@1.0.1:
@@ -12351,6 +12582,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wonka@6.3.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ packages:
 
     - "tests/e2e"
     - "tests/types"
+    - "tests/unit"
 allowBuilds:
     "@swc/core": true
     better-sqlite3: true

--- a/tests/unit/package.json
+++ b/tests/unit/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "@pluv-tests/unit",
+    "version": "0.0.0",
+    "sideEffects": false,
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "typecheck": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@pluv/crdt": "workspace:^",
+        "@pluv/crdt-loro": "workspace:^",
+        "@pluv/crdt-yjs": "workspace:^",
+        "@pluv/io": "workspace:^",
+        "@pluv/types": "workspace:^",
+        "loro-crdt": "^1.16.0",
+        "yjs": "^13.6.32"
+    },
+    "devDependencies": {
+        "@pluv/tsconfig": "workspace:^",
+        "@types/node": "^26.4.1",
+        "typescript": "^7.0.2",
+        "vitest": "^4.1.11"
+    }
+}

--- a/tests/unit/src/IORoom.teardown.test.ts
+++ b/tests/unit/src/IORoom.teardown.test.ts
@@ -1,0 +1,93 @@
+import { yjs } from "@pluv/crdt-yjs";
+import { createIO } from "@pluv/io";
+import { describe, expect, it } from "vitest";
+import type { Deferred } from "./__utils__";
+import {
+    deferred,
+    encodedStateWithContent,
+    isEmptyEncodedState,
+    TestPlatform,
+    TestSocket,
+    tick,
+    waitUntil,
+} from "./__utils__";
+
+const SEEDED_CONTENT = "content that must survive teardown";
+
+/**
+ * @description Hydrates the room from `getInitialStorage`, as happens after a Durable Object
+ * hibernates. The first `onStorageDestroyed` blocks on a gate so a test can hold a teardown
+ * open and interleave against it.
+ */
+const setupRoom = (roomId: string) => {
+    const seeded = encodedStateWithContent(SEEDED_CONTENT);
+    const destroyed: (string | null)[] = [];
+    const gate: Deferred<void> = deferred();
+
+    let shouldBlock = true;
+
+    const io = createIO({ crdt: yjs, platform: () => new TestPlatform() });
+    const server = io.server({
+        getInitialStorage: () => Promise.resolve(seeded),
+        onStorageDestroyed: async ({ encodedState }) => {
+            destroyed.push(encodedState);
+
+            if (!shouldBlock) return;
+
+            shouldBlock = false;
+
+            await gate.promise;
+        },
+    });
+
+    return { destroyed, gate, room: server.createRoom(roomId), seeded };
+};
+
+describe("IORoom teardown", () => {
+    it("persists storage once, and never persists an empty document", async () => {
+        const { destroyed, gate, room } = setupRoom("overlapping-teardowns");
+
+        await room.register(new TestSocket("session-1"));
+
+        // Held open inside its onStorageDestroyed webhook.
+        const firstTeardown = room.evictAll();
+
+        await waitUntil(() => destroyed.length >= 1);
+
+        const secondTeardown = room.evictAll();
+
+        await tick(3);
+
+        gate.resolve();
+
+        await Promise.all([firstTeardown, secondTeardown]);
+
+        expect(destroyed.filter((state) => isEmptyEncodedState(state))).toEqual([]);
+        expect(destroyed).toHaveLength(1);
+    });
+
+    it("does not hand a late connection an empty document while teardown is in-flight", async () => {
+        const { destroyed, gate, room } = setupRoom("register-during-teardown");
+
+        await room.register(new TestSocket("session-1"));
+
+        const teardown = room.evictAll();
+
+        await waitUntil(() => destroyed.length >= 1);
+
+        // The room is mid-teardown, so its doc has already been cleared.
+        const late = new TestSocket("session-2");
+        const registration = room.register(late);
+
+        await tick(2);
+
+        gate.resolve();
+
+        await Promise.all([teardown, registration]);
+
+        const registered = late.messages.find((message) => message.type === "$registered");
+
+        expect(registered).toBeDefined();
+        expect(isEmptyEncodedState(registered?.data?.state ?? null)).toBe(false);
+    });
+});

--- a/tests/unit/src/__utils__/TestPlatform.ts
+++ b/tests/unit/src/__utils__/TestPlatform.ts
@@ -1,0 +1,159 @@
+import type {
+    AbstractPersistence,
+    AbstractPlatformConfig,
+    AbstractPubSub,
+    ConvertWebSocketConfig,
+    WebSocketRegistrationMode,
+    WebSocketSerializedState,
+} from "@pluv/io";
+import { AbstractPlatform } from "@pluv/io";
+import type { IOAuthorize } from "@pluv/types";
+import crypto from "node:crypto";
+import { TestSocket, TestWebSocket } from "./TestWebSocket";
+
+export type TestPlatformConfig = {
+    mode?: WebSocketRegistrationMode;
+    persistence?: AbstractPersistence;
+    pubSub?: AbstractPubSub;
+    /** Sockets reported as pre-existing, as Cloudflare does after waking from hibernation. */
+    hibernatedWebSockets?: readonly TestSocket[];
+    serializedStates?: ReadonlyMap<TestSocket, WebSocketSerializedState>;
+};
+
+/**
+ * @description The config generic must be spelled out with literal types. Left to the default
+ * `PlatformConfig`, the flags widen to `boolean` and `@pluv/io` infers that listeners such as
+ * `onStorageDestroyed` are unsupported.
+ */
+export class TestPlatform<
+    TAuthorize extends IOAuthorize<any, any> | null = null,
+> extends AbstractPlatform<
+    TestWebSocket<TAuthorize>,
+    {},
+    {},
+    {
+        authorize: { secret: true };
+        handleMode: "io";
+        requireAuth: false;
+        registrationMode: WebSocketRegistrationMode;
+        listeners: {
+            onRoomDestroyed: true;
+            onRoomMessage: true;
+            onStorageDestroyed: true;
+            onStorageUpdated: true;
+            onUserConnected: true;
+            onUserDisconnected: true;
+        };
+        router: true;
+    }
+> {
+    public readonly id = crypto.randomUUID();
+    public readonly _config;
+    public readonly _name = "platformTest";
+
+    private readonly _hibernatedWebSockets: readonly TestSocket[];
+    private readonly _mode: WebSocketRegistrationMode;
+    private readonly _serializedStates: ReadonlyMap<TestSocket, WebSocketSerializedState>;
+    // Stable per socket, otherwise presence/quit/ping state is discarded between calls.
+    private readonly _wrapped = new Map<TestSocket, TestWebSocket<TAuthorize>>();
+
+    constructor(config: TestPlatformConfig = {}) {
+        const {
+            hibernatedWebSockets = [],
+            mode = "attached",
+            persistence,
+            pubSub,
+            serializedStates = new Map<TestSocket, WebSocketSerializedState>(),
+        } = config;
+
+        super(persistence && pubSub ? { persistence, pubSub } : {});
+
+        this._hibernatedWebSockets = hibernatedWebSockets;
+        this._mode = mode;
+        this._serializedStates = serializedStates;
+
+        this._config = {
+            authorize: { secret: true as const },
+            handleMode: "io" as const,
+            registrationMode: mode,
+            requireAuth: false as const,
+            listeners: {
+                onRoomDestroyed: true as const,
+                onStorageDestroyed: true as const,
+                onStorageUpdated: true as const,
+                onUserConnected: true as const,
+                onUserDisconnected: true as const,
+                onRoomMessage: true as const,
+            },
+            router: true as const,
+        };
+    }
+
+    public acceptWebSocket(): Promise<void> {
+        return Promise.resolve(undefined);
+    }
+
+    public convertWebSocket(
+        webSocket: TestSocket,
+        config: ConvertWebSocketConfig,
+    ): TestWebSocket<TAuthorize> {
+        const existing = this._wrapped.get(webSocket);
+
+        if (existing) return existing;
+
+        const converted = new TestWebSocket<TAuthorize>(webSocket, {
+            persistence: this.persistence,
+            platform: this,
+            room: config.room,
+        });
+
+        this._wrapped.set(webSocket, converted);
+
+        return converted;
+    }
+
+    public getLastPing(): number | null {
+        return null;
+    }
+
+    public getSerializedState(webSocket: TestSocket): WebSocketSerializedState | null {
+        return this._serializedStates.get(webSocket) ?? null;
+    }
+
+    public getSessionId(webSocket: TestSocket): string | null {
+        return webSocket.id;
+    }
+
+    public getWebSockets(): readonly TestSocket[] {
+        return this._hibernatedWebSockets;
+    }
+
+    public initialize(config: AbstractPlatformConfig<{}>): this {
+        return new TestPlatform<TAuthorize>({
+            hibernatedWebSockets: this._hibernatedWebSockets,
+            mode: this._mode,
+            persistence: this.persistence.initialize(config.roomContext),
+            pubSub: this.pubSub,
+            serializedStates: this._serializedStates,
+        })._initialize() as this;
+    }
+
+    public parseData(data: string | ArrayBuffer): Record<string, any> {
+        if (typeof data === "string") return JSON.parse(data);
+
+        return JSON.parse(new TextDecoder().decode(data));
+    }
+
+    public randomUUID(): string {
+        return crypto.randomUUID();
+    }
+
+    public setSerializedState(
+        webSocket: TestWebSocket<TAuthorize>,
+        state: WebSocketSerializedState,
+    ): WebSocketSerializedState {
+        webSocket.state = state;
+
+        return webSocket.state;
+    }
+}

--- a/tests/unit/src/__utils__/TestWebSocket.ts
+++ b/tests/unit/src/__utils__/TestWebSocket.ts
@@ -1,0 +1,133 @@
+import type {
+    AbstractEventMap,
+    AbstractListener,
+    AbstractWebSocketConfig,
+    WebSocketSerializedState,
+    WebSocketSession,
+} from "@pluv/io";
+import { AbstractWebSocket } from "@pluv/io";
+import type { InferIOAuthorizeUser, IOAuthorize, JsonObject } from "@pluv/types";
+
+type TestSocketListener = (event: any) => unknown;
+
+/**
+ * @description Stands in for the runtime-provided socket (`ws.WebSocket`, a Cloudflare
+ * WebSocket, etc). The id doubles as the session id, so sessions are deterministic.
+ */
+export class TestSocket {
+    public readonly id: string;
+    public readonly sent: string[] = [];
+    public readyState: 0 | 1 | 2 | 3 = 1;
+
+    private readonly _listeners = new Map<string, Set<TestSocketListener>>();
+
+    constructor(id: string) {
+        this.id = id;
+    }
+
+    public addListener(type: string, listener: TestSocketListener): void {
+        const listeners = this._listeners.get(type) ?? new Set<TestSocketListener>();
+
+        this._listeners.set(type, listeners);
+        listeners.add(listener);
+    }
+
+    public async emit(type: string, event: unknown): Promise<void> {
+        const listeners = Array.from(this._listeners.get(type) ?? []);
+
+        for (const listener of listeners) await Promise.resolve(listener(event));
+    }
+
+    public get messages(): { type: string; data: any }[] {
+        return this.sent.map((message) => JSON.parse(message));
+    }
+}
+
+export class TestWebSocket<
+    TAuthorize extends IOAuthorize<any, any> | null = null,
+> extends AbstractWebSocket<TestSocket> {
+    private _state: WebSocketSerializedState;
+    private _user: InferIOAuthorizeUser<TAuthorize> = null as InferIOAuthorizeUser<TAuthorize>;
+
+    public set presence(presence: JsonObject | null) {
+        this._state.presence = presence;
+    }
+
+    public get readyState(): 0 | 1 | 2 | 3 {
+        return this.webSocket.readyState;
+    }
+
+    public get session(): WebSocketSession<TAuthorize> {
+        return {
+            ...this._state,
+            id: this.sessionId,
+            user: this._user,
+            webSocket: this,
+        };
+    }
+
+    public get sessionId(): string {
+        return this.webSocket.id;
+    }
+
+    public get state(): WebSocketSerializedState {
+        return this._state;
+    }
+
+    public set state(state: WebSocketSerializedState) {
+        this._state = state;
+    }
+
+    public set user(user: InferIOAuthorizeUser<TAuthorize>) {
+        this._user = user;
+    }
+
+    constructor(webSocket: TestSocket, config: AbstractWebSocketConfig) {
+        const { room } = config;
+
+        super(webSocket, config);
+
+        this._state = {
+            presence: null,
+            quit: false,
+            room,
+            timers: {
+                ping: new Date().getTime(),
+                presence: null,
+            },
+        };
+    }
+
+    public addEventListener<TType extends keyof AbstractEventMap>(
+        type: TType,
+        handler: AbstractListener<TType>,
+    ): void {
+        this.webSocket.addListener(type, handler as TestSocketListener);
+    }
+
+    public close(code?: number, reason?: string): void {
+        const canClose = [this.CONNECTING, this.OPEN].some(
+            (readyState) => readyState === this.readyState,
+        );
+
+        if (!canClose) return;
+
+        this.webSocket.readyState = this.CLOSED;
+
+        void this.webSocket.emit("close", { code: code ?? 1_000, reason: reason ?? "" });
+    }
+
+    public send(message: string | ArrayBuffer | ArrayBufferView): void {
+        if (this.readyState !== this.OPEN) return;
+
+        this.webSocket.sent.push(
+            typeof message === "string"
+                ? message
+                : new TextDecoder().decode(message as ArrayBuffer),
+        );
+    }
+
+    public terminate(): void {
+        this.webSocket.readyState = this.CLOSED;
+    }
+}

--- a/tests/unit/src/__utils__/helpers.ts
+++ b/tests/unit/src/__utils__/helpers.ts
@@ -1,0 +1,48 @@
+import { Doc as YDoc, encodeStateAsUpdate } from "yjs";
+
+export interface Deferred<T> {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+}
+
+export const deferred = <T = void>(): Deferred<T> => {
+    let resolve!: (value: T) => void;
+
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+
+    return { promise, resolve };
+};
+
+/** Drains pending microtasks, advancing an in-flight teardown to its next suspension point. */
+export const tick = async (times: number = 1): Promise<void> => {
+    for (let i = 0; i < times; i += 1) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    }
+};
+
+export const waitUntil = async (predicate: () => boolean, timeoutMs: number = 5_000) => {
+    const start = Date.now();
+
+    while (!predicate()) {
+        if (Date.now() - start > timeoutMs) throw new Error("Timed out waiting for condition");
+
+        await tick();
+    }
+};
+
+export const encodedStateWithContent = (text: string): string => {
+    const doc = new YDoc();
+
+    doc.getText("content").insert(0, text);
+
+    return Buffer.from(encodeStateAsUpdate(doc)).toString("base64");
+};
+
+/** Yjs-specific. A pristine Y.Doc encodes to the 2-byte "AAA=" payload that wiped storage. */
+export const isEmptyEncodedState = (encodedState: string | null): boolean => {
+    if (!encodedState) return true;
+
+    return Buffer.from(encodedState, "base64").byteLength <= 2;
+};

--- a/tests/unit/src/__utils__/index.ts
+++ b/tests/unit/src/__utils__/index.ts
@@ -1,0 +1,5 @@
+export type { Deferred } from "./helpers";
+export { deferred, encodedStateWithContent, isEmptyEncodedState, tick, waitUntil } from "./helpers";
+export { TestPlatform } from "./TestPlatform";
+export type { TestPlatformConfig } from "./TestPlatform";
+export { TestSocket, TestWebSocket } from "./TestWebSocket";

--- a/tests/unit/src/documentDirtiness.test.ts
+++ b/tests/unit/src/documentDirtiness.test.ts
@@ -1,0 +1,87 @@
+import { loro } from "@pluv/crdt-loro";
+import { yjs } from "@pluv/crdt-yjs";
+import { describe, expect, it } from "vitest";
+
+const AUTHORED_CONTENT = "content that the user will delete";
+
+/**
+ * @description `roomDoc` mirrors how `IORoom` builds its document: no storage keys, hydrated
+ * entirely from an encoded state. Scenarios return encoded states so the shared assertions
+ * below stay free of CRDT-specific types.
+ */
+const scenarios = [
+    {
+        name: "yjs",
+        roomDoc: () => yjs.doc(() => ({})).getEmpty(),
+        authoredState: () =>
+            yjs
+                .doc((t) => ({ content: t.text("content", AUTHORED_CONTENT) }))
+                .getInitialized()
+                .getEncodedState(),
+        deletedState: () => {
+            const doc = yjs
+                .doc((t) => ({ content: t.text("content", AUTHORED_CONTENT) }))
+                .getInitialized();
+            const text = doc.get("content");
+
+            text.delete(0, text.length);
+
+            return doc.getEncodedState();
+        },
+    },
+    {
+        name: "loro",
+        roomDoc: () => loro.doc(() => ({})).getEmpty(),
+        authoredState: () =>
+            loro
+                .doc((t) => ({ content: t.text("content", AUTHORED_CONTENT) }))
+                .getInitialized()
+                .getEncodedState(),
+        deletedState: () => {
+            const doc = loro
+                .doc((t) => ({ content: t.text("content", AUTHORED_CONTENT) }))
+                .getInitialized();
+            const text = doc.get("content");
+
+            text.delete(0, text.length);
+
+            return doc.getEncodedState();
+        },
+    },
+] as const;
+
+// Teardown skips persisting an unwritten document, which is only safe while "never written
+// to" and "the user deleted everything" stay distinguishable for every CRDT pluv supports.
+describe.each(scenarios)("$name document dirtiness", ({ authoredState, deletedState, roomDoc }) => {
+    it("reports a document that has never been written to as clean", () => {
+        expect(roomDoc().isDirty()).toBe(false);
+    });
+
+    it("stays clean when an empty encoded state is applied", () => {
+        const update = roomDoc().getEncodedState();
+
+        expect(roomDoc().applyEncodedState({ update }).isDirty()).toBe(false);
+    });
+
+    it("reports a document hydrated with content as dirty", () => {
+        expect(roomDoc().applyEncodedState({ update: authoredState() }).isDirty()).toBe(true);
+    });
+
+    it("still reports a document as dirty after all of its content is deleted", () => {
+        expect(roomDoc().applyEncodedState({ update: deletedState() }).isDirty()).toBe(true);
+    });
+});
+
+describe("yjs isDirty vs isEmpty", () => {
+    // Why teardown cannot key off `isEmpty()`: binding an editor to a shared type registers it
+    // without writing anything, which is what BlockNote does before the user types.
+    it("treats a registered but unwritten shared type as clean, where isEmpty does not", () => {
+        const doc = yjs.doc(() => ({})).getEmpty();
+
+        doc.value.getText("content");
+
+        expect(doc.isEmpty()).toBe(false);
+        expect(doc.isDirty()).toBe(false);
+        expect(doc.getEncodedState()).toBe("AAA=");
+    });
+});

--- a/tests/unit/tsconfig.json
+++ b/tests/unit/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "@pluv/tsconfig/library.json",
+    "include": ["src/**/*.ts", "vitest.config.ts"],
+    "exclude": ["node_modules"],
+    "compilerOptions": {
+        "lib": ["esnext"],
+        "noEmit": true,
+        "strict": true,
+        "types": ["node"]
+    }
+}

--- a/tests/unit/vitest.config.ts
+++ b/tests/unit/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        environment: "node",
+        include: ["src/**/*.test.ts"],
+        // Overlapping teardowns can deadlock rather than fail, so fail fast instead.
+        testTimeout: 10_000,
+    },
+});


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/main/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Prevent room teardown from persisting an empty document over saved storage.

- `IORoom` teardown is now atomic. A second teardown joins the one already in flight instead of re-running it and emitting `onStorageDestroyed` with a document that was already cleared.
- `IORoom.register` now waits for an in-flight teardown, so a connection arriving mid-teardown re-initializes from storage instead of binding to the cleared document.
- Added `isDirty()` to `CrdtDocLike`, implemented for the yjs, loro and noop documents. It reports whether a document has ever been written to, and teardown uses it to skip `onStorageDestroyed` for a document that never was. It is not the inverse of `isEmpty()`: deleting all content leaves a document dirty, so emptied storage still persists.
- Breaking for external `CrdtDocLike` implementations: `isDirty()` is a new required member.
