### PR TITLE
fix(io): preserve healthy hibernated sockets

### DIFF
--- a/.changeset/healthy-hibernated-sockets.md
+++ b/.changeset/healthy-hibernated-sockets.md
@@ -1,0 +1,7 @@
+---
+"@pluv/io": patch
+---
+
+Prevent garbage collection from evicting healthy hibernated WebSockets.
+
+`IORoom` now uses the platform's latest ping timestamp when finding timed-out connections. This keeps Cloudflare WebSockets alive when their auto-response timestamp is newer than the serialized ping stored before hibernation.

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -528,7 +528,9 @@ export class IORoom<
     private async _emitQuitters(): Promise<void> {
         const currentTime = new Date().getTime();
         const quitters = Array.from(this._sessions.values()).filter((pluvWs) => {
-            return pluvWs.state.quit || currentTime - pluvWs.state.timers.ping > PING_TIMEOUT_MS;
+            const pingTime = this._platform.getLastPing(pluvWs) ?? pluvWs.state.timers.ping;
+
+            return pluvWs.state.quit || currentTime - pingTime > PING_TIMEOUT_MS;
         });
 
         await this._closeWebSockets(quitters);

--- a/tests/unit/src/IORoom.hibernation.test.ts
+++ b/tests/unit/src/IORoom.hibernation.test.ts
@@ -1,0 +1,83 @@
+import { yjs } from "@pluv/crdt-yjs";
+import { createIO } from "@pluv/io";
+import { applyUpdate, Doc as YDoc, encodeStateAsUpdate, encodeStateVector } from "yjs";
+import { describe, expect, it, vi } from "vitest";
+import { encodedStateWithContent, TestPersistence, TestPlatform, TestSocket } from "./__utils__";
+
+describe("IORoom hibernation", () => {
+    it("does not evict a hibernated socket with a recent auto-response ping", async () => {
+        const roomId = "hibernated-heartbeat";
+        const socket = new TestSocket("session-1");
+        const persistence = new TestPersistence();
+        const onStorageDestroyed = vi.fn();
+        const now = Date.now();
+
+        await persistence.setStorageState(roomId, encodedStateWithContent("current"));
+
+        const io = createIO({
+            crdt: yjs,
+            platform: () =>
+                new TestPlatform({
+                    hibernatedWebSockets: [socket],
+                    lastPings: new Map([[socket, now]]),
+                    mode: "detached",
+                    persistence,
+                    serializedStates: new Map([
+                        [
+                            socket,
+                            {
+                                presence: null,
+                                quit: false,
+                                room: roomId,
+                                timers: {
+                                    ping: now - 60_000,
+                                    presence: null,
+                                },
+                            },
+                        ],
+                    ]),
+                }),
+        });
+        const server = io.server({
+            getInitialStorage: () => Promise.resolve(null),
+            onStorageDestroyed,
+        });
+        const room = server.createRoom(roomId);
+
+        expect(room.getSize()).toBe(1);
+
+        await room.garbageCollect();
+
+        expect(room.getSize()).toBe(1);
+        expect(onStorageDestroyed).not.toHaveBeenCalled();
+
+        const stored = await persistence.getStorageState(roomId);
+        const clientDoc = new YDoc();
+
+        applyUpdate(clientDoc, Buffer.from(stored!, "base64"));
+
+        const stateVector = encodeStateVector(clientDoc);
+        const content = clientDoc.getText("content");
+
+        content.insert(content.length, " latest");
+
+        await room.onMessage(socket)({
+            data: JSON.stringify({
+                type: "$updateStorage",
+                data: {
+                    origin: null,
+                    update: Buffer.from(encodeStateAsUpdate(clientDoc, stateVector)).toString(
+                        "base64",
+                    ),
+                },
+            }),
+        });
+
+        const updated = new YDoc();
+        const updatedState = await persistence.getStorageState(roomId);
+
+        applyUpdate(updated, Buffer.from(updatedState!, "base64"));
+
+        expect(updated.getText("content").toJSON()).toBe("current latest");
+    });
+});

--- a/tests/unit/src/__utils__/TestPlatform.ts
+++ b/tests/unit/src/__utils__/TestPlatform.ts
@@ -17,6 +17,7 @@ export type TestPlatformConfig = {
     pubSub?: AbstractPubSub;
     /** Sockets reported as pre-existing, as Cloudflare does after waking from hibernation. */
     hibernatedWebSockets?: readonly TestSocket[];
+    lastPings?: ReadonlyMap<TestSocket, number>;
     serializedStates?: ReadonlyMap<TestSocket, WebSocketSerializedState>;
 };
 
@@ -52,6 +53,7 @@ export class TestPlatform<
     public readonly _name = "platformTest";
 
     private readonly _hibernatedWebSockets: readonly TestSocket[];
+    private readonly _lastPings: ReadonlyMap<TestSocket, number>;
     private readonly _mode: WebSocketRegistrationMode;
     private readonly _serializedStates: ReadonlyMap<TestSocket, WebSocketSerializedState>;
     // Stable per socket, otherwise presence/quit/ping state is discarded between calls.
@@ -60,6 +62,7 @@ export class TestPlatform<
     constructor(config: TestPlatformConfig = {}) {
         const {
             hibernatedWebSockets = [],
+            lastPings = new Map<TestSocket, number>(),
             mode = "attached",
             persistence,
             pubSub,
@@ -69,6 +72,7 @@ export class TestPlatform<
         super({ persistence, pubSub });
 
         this._hibernatedWebSockets = hibernatedWebSockets;
+        this._lastPings = lastPings;
         this._mode = mode;
         this._serializedStates = serializedStates;
 
@@ -106,14 +110,16 @@ export class TestPlatform<
             platform: this,
             room: config.room,
         });
+        const serializedState = this._serializedStates.get(webSocket);
 
+        if (serializedState) converted.state = serializedState;
         this._wrapped.set(webSocket, converted);
 
         return converted;
     }
 
-    public getLastPing(): number | null {
-        return null;
+    public getLastPing(webSocket: TestWebSocket<TAuthorize>): number | null {
+        return this._lastPings.get(webSocket.webSocket) ?? null;
     }
 
     public getSerializedState(webSocket: TestSocket): WebSocketSerializedState | null {
@@ -131,6 +137,7 @@ export class TestPlatform<
     public initialize(config: AbstractPlatformConfig<{}>): this {
         return new TestPlatform<TAuthorize>({
             hibernatedWebSockets: this._hibernatedWebSockets,
+            lastPings: this._lastPings,
             mode: this._mode,
             persistence: this.persistence.initialize(config.roomContext),
             pubSub: this.pubSub,


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/main/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Prevent garbage collection from evicting healthy hibernated WebSockets.

`IORoom` now uses the platform's latest ping timestamp when finding timed-out connections. This keeps Cloudflare WebSockets alive when their auto-response timestamp is newer than the serialized ping stored before hibernation.
