### PR TITLE
fix: cloudflare sqlite hibernation

### DIFF
--- a/.changeset/cloudflare-sqlite-hibernation.md
+++ b/.changeset/cloudflare-sqlite-hibernation.md
@@ -1,0 +1,11 @@
+---
+"@pluv/persistence-cloudflare-transactional-storage": patch
+"@pluv/platform-cloudflare": patch
+---
+
+Fix Cloudflare room storage being lost after Durable Object hibernation.
+
+`$updateStorage` was writing to the default in-memory persistence because `CloudflarePlatform.initialize()` reused that adapter instead of Durable Object SQLite. Hibernation dropped the in-memory map, so a later reload restored the last `onStorageDestroyed` snapshot.
+
+- `CloudflarePlatform.initialize()` now attaches `PersistenceCloudflareTransactionalStorage` (sqlite) unless a custom persistence adapter was provided.
+- `PersistenceCloudflareTransactionalStorage.initialize()` now copies Durable Object state onto the returned instance, so reads and writes actually hit SQLite instead of no-opping.

--- a/packages/persistence-cloudflare-transactional-storage/src/PersistenceCloudflareTransactionalStorage.ts
+++ b/packages/persistence-cloudflare-transactional-storage/src/PersistenceCloudflareTransactionalStorage.ts
@@ -29,6 +29,7 @@ export class PersistenceCloudflareTransactionalStorage extends AbstractPersisten
         const { mode } = config;
 
         this._initialized = (config as any)._initialized;
+        this._state = (config as any)._state ?? null;
         this._mode = mode;
     }
 
@@ -289,13 +290,11 @@ export class PersistenceCloudflareTransactionalStorage extends AbstractPersisten
     }
 
     public initialize(roomContext: { state: DurableObjectState }): typeof this {
+        const { state } = roomContext;
+
         const initialized = (async () => {
-            const { state } = roomContext;
-
-            this._state = state;
-
             if (this._mode === "sqlite") {
-                this._state.storage.sql.exec(sql`
+                state.storage.sql.exec(sql`
                     CREATE TABLE IF NOT EXISTS ${SQLITE_STORAGE_TABLE}(
                         room TEXT PRIMARY KEY,
                         data TEXT NOT NULL
@@ -314,10 +313,10 @@ export class PersistenceCloudflareTransactionalStorage extends AbstractPersisten
 
         return new PersistenceCloudflareTransactionalStorage({
             mode: this._mode,
-            // Spreading avoids an excess property check, so `_initialized` can be handed to the
-            // constructor without exposing it on the public config type.
+            // Spreading avoids an excess property check, so `_initialized` and `_state` can be
+            // handed to the constructor without exposing them on the public config type.
             // oxlint-disable-next-line unicorn/no-useless-spread
-            ...{ _initialized: initialized },
+            ...{ _initialized: initialized, _state: state },
         }) as typeof this;
     }
 

--- a/packages/platform-cloudflare/src/CloudflarePlatform.ts
+++ b/packages/platform-cloudflare/src/CloudflarePlatform.ts
@@ -55,10 +55,12 @@ export class CloudflarePlatform<
     public readonly _config;
     public readonly _name = "platformCloudflare";
 
+    private readonly _persistenceProvided: boolean;
+
     constructor(config: CloudflarePlatformConfig<TEnv, TMeta>) {
         super({
             ...config,
-            ...(config.roomContext && config.mode === "detached"
+            ...(config.roomContext && (config.mode ?? DEFAULT_REGISTRATION_MODE) === "detached"
                 ? {
                       persistence:
                           config.persistence ??
@@ -66,6 +68,8 @@ export class CloudflarePlatform<
                   }
                 : {}),
         });
+
+        this._persistenceProvided = !!config.persistence;
 
         this._config = {
             authorize: {
@@ -170,10 +174,16 @@ export class CloudflarePlatform<
             state: ctx.state,
         } as CloudflarePlatformRoomContext<TEnv, TMeta>;
 
+        const persistence = (
+            this._persistenceProvided
+                ? this.persistence
+                : new PersistenceCloudflareTransactionalStorage({ mode: "sqlite" })
+        ).initialize(roomContext);
+
         return new CloudflarePlatform<TAuthorize, TEnv, TMeta>({
             roomContext,
             mode: this._config.registrationMode,
-            persistence: this.persistence.initialize(roomContext),
+            persistence,
             pubSub: this.pubSub,
         })._initialize() as this;
     }

--- a/tests/unit/src/CloudflarePlatform.persistence.test.ts
+++ b/tests/unit/src/CloudflarePlatform.persistence.test.ts
@@ -1,0 +1,58 @@
+import { PersistenceCloudflareTransactionalStorage } from "@pluv/persistence-cloudflare-transactional-storage";
+import { platformCloudflare } from "@pluv/platform-cloudflare";
+import { beforeAll, describe, expect, it } from "vitest";
+import { createMockDurableObjectState, TestPersistence } from "./__utils__";
+
+const LATEST_SNAPSHOT = "snapshot-after-second-edit";
+
+beforeAll(() => {
+    class WebSocketRequestResponsePair {
+        public constructor(
+            public readonly request: string,
+            public readonly response: string,
+        ) {}
+    }
+
+    Object.assign(globalThis, { WebSocketRequestResponsePair });
+});
+
+describe("CloudflarePlatform persistence", () => {
+    it("uses Durable Object storage after initialize, not the in-memory default", () => {
+        const { platform } = platformCloudflare();
+        const initialized = platform().initialize({
+            roomContext: { env: {}, state: createMockDurableObjectState() },
+        });
+
+        expect(initialized.persistence).toBeInstanceOf(PersistenceCloudflareTransactionalStorage);
+    });
+
+    it("keeps $updateStorage writes across a new platform() after hibernation", async () => {
+        const { platform } = platformCloudflare();
+        const state = createMockDurableObjectState();
+        const roomContext = { env: {}, state };
+
+        const beforeHibernation = platform().initialize({ roomContext });
+
+        await beforeHibernation.persistence.setStorageState("home-page", LATEST_SNAPSHOT);
+
+        const afterHibernation = platform().initialize({ roomContext });
+
+        await expect(afterHibernation.persistence.getStorageState("home-page")).resolves.toBe(
+            LATEST_SNAPSHOT,
+        );
+    });
+
+    it("keeps a caller-provided persistence adapter", async () => {
+        const persistence = new TestPersistence();
+
+        await persistence.setStorageState("home-page", "custom");
+
+        const { platform } = platformCloudflare({ persistence });
+        const initialized = platform().initialize({
+            roomContext: { env: {}, state: createMockDurableObjectState() },
+        });
+
+        expect(initialized.persistence).toBeInstanceOf(TestPersistence);
+        await expect(initialized.persistence.getStorageState("home-page")).resolves.toBe("custom");
+    });
+});

--- a/tests/unit/src/PersistenceCloudflareTransactionalStorage.test.ts
+++ b/tests/unit/src/PersistenceCloudflareTransactionalStorage.test.ts
@@ -1,0 +1,32 @@
+import { PersistenceCloudflareTransactionalStorage } from "@pluv/persistence-cloudflare-transactional-storage";
+import { describe, expect, it } from "vitest";
+import { createMockDurableObjectState } from "./__utils__";
+
+const ROOM_ID = "home-page";
+const LATEST_SNAPSHOT = "snapshot-after-second-edit";
+
+describe("PersistenceCloudflareTransactionalStorage", () => {
+    it("writes and reads on the instance returned by initialize", async () => {
+        const persistence = new PersistenceCloudflareTransactionalStorage({
+            mode: "sqlite",
+        }).initialize({ state: createMockDurableObjectState() });
+
+        await persistence.setStorageState(ROOM_ID, LATEST_SNAPSHOT);
+
+        await expect(persistence.getStorageState(ROOM_ID)).resolves.toBe(LATEST_SNAPSHOT);
+    });
+
+    it("keeps writes across a new initialize with the same Durable Object state", async () => {
+        const state = createMockDurableObjectState();
+
+        await new PersistenceCloudflareTransactionalStorage({ mode: "sqlite" })
+            .initialize({ state })
+            .setStorageState(ROOM_ID, LATEST_SNAPSHOT);
+
+        const revived = new PersistenceCloudflareTransactionalStorage({
+            mode: "sqlite",
+        }).initialize({ state });
+
+        await expect(revived.getStorageState(ROOM_ID)).resolves.toBe(LATEST_SNAPSHOT);
+    });
+});

--- a/tests/unit/src/__utils__/index.ts
+++ b/tests/unit/src/__utils__/index.ts
@@ -4,3 +4,4 @@ export { TestPersistence } from "./TestPersistence";
 export { TestPlatform } from "./TestPlatform";
 export type { TestPlatformConfig } from "./TestPlatform";
 export { TestSocket, TestWebSocket } from "./TestWebSocket";
+export { createMockDurableObjectState } from "./mockDurableObjectState";

--- a/tests/unit/src/__utils__/mockDurableObjectState.ts
+++ b/tests/unit/src/__utils__/mockDurableObjectState.ts
@@ -1,0 +1,71 @@
+interface SqlResult {
+    one(): { count?: number; data?: string; room?: string };
+    toArray(): { count?: number }[];
+}
+
+const emptyResult = (): SqlResult => ({
+    one: () => {
+        throw new Error("No rows");
+    },
+    toArray: () => [],
+});
+
+/**
+ * Minimal Durable Object SQL/storage stand-in for `PersistenceCloudflareTransactionalStorage`.
+ * Shared across `platform()` calls the way isolate hibernation reuses DO storage.
+ */
+export const createMockDurableObjectState = (): any => {
+    const storage = new Map<string, string>();
+
+    const exec = (query: string, ...binds: unknown[]): SqlResult => {
+        if (query.includes("CREATE TABLE")) return emptyResult();
+
+        if (query.includes("SELECT COUNT(*)")) {
+            const room = String(binds[0]);
+
+            return {
+                one: () => ({ count: storage.has(room) ? 1 : 0 }),
+                toArray: () => [{ count: storage.has(room) ? 1 : 0 }],
+            };
+        }
+
+        if (query.includes("UPDATE") && query.includes("__pluv_storage")) {
+            storage.set(String(binds[1]), String(binds[0]));
+            return emptyResult();
+        }
+
+        if (query.includes("INSERT INTO __pluv_storage")) {
+            storage.set(String(binds[0]), String(binds[1]));
+            return emptyResult();
+        }
+
+        if (query.includes("SELECT room, data")) {
+            const room = String(binds[0]);
+            const data = storage.get(room);
+
+            if (typeof data !== "string") return emptyResult();
+
+            return {
+                one: () => ({ room, data }),
+                toArray: () => [{ count: 1 }],
+            };
+        }
+
+        if (query.includes("DELETE FROM __pluv_storage")) {
+            storage.delete(String(binds[0]));
+            return emptyResult();
+        }
+
+        return emptyResult();
+    };
+
+    return {
+        storage: {
+            sql: { exec },
+        },
+        acceptWebSocket: () => undefined,
+        getWebSockets: () => [],
+        getWebSocketAutoResponseTimestamp: () => null,
+        setWebSocketAutoResponse: () => undefined,
+    };
+};


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/main/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fix Cloudflare room storage being lost after Durable Object hibernation.

`$updateStorage` was writing to the default in-memory persistence because `CloudflarePlatform.initialize()` reused that adapter instead of Durable Object SQLite. Hibernation dropped the in-memory map, so a later reload restored the last `onStorageDestroyed` snapshot.

- `CloudflarePlatform.initialize()` now attaches `PersistenceCloudflareTransactionalStorage` (sqlite) unless a custom persistence adapter was provided.
- `PersistenceCloudflareTransactionalStorage.initialize()` now copies Durable Object state onto the returned instance, so reads and writes actually hit SQLite instead of no-opping.