### PR TITLE
Fix/io initial storage seed

### DIFF
--- a/.changeset/soft-lizards-bathe.md
+++ b/.changeset/soft-lizards-bathe.md
@@ -1,0 +1,12 @@
+---
+"@pluv/io": patch
+"@pluv/crdt-yjs": patch
+"@pluv/crdt-loro": patch
+---
+
+Loaded room storage is no longer overwritten when another client joins with `initialStorage`.
+
+- Persistence and `getInitialStorage` take priority over a client's `initialStorage`. Joining an already-seeded room leaves that storage unchanged.
+- The client's `$initialized` storage echo is ignored, so a local snapshot cannot replace server state after load.
+- Two clients connecting at once only load `getInitialStorage` once. If they both try to seed an empty room, only the first `initialStorage` is applied.
+- Yjs and Loro `toJson()` now return the document's actual contents, including when storage was loaded from an encoded snapshot instead of a schema.

--- a/packages/crdt-loro/src/doc/CrdtLoroDoc.ts
+++ b/packages/crdt-loro/src/doc/CrdtLoroDoc.ts
@@ -132,23 +132,25 @@ export class CrdtLoroDoc<
     public toJson(): InferCrdtJson<TStorage>;
     public toJson<TKey extends keyof TStorage>(type: TKey): InferCrdtJson<TStorage[TKey]>;
     public toJson<TKey extends keyof TStorage>(type?: TKey) {
-        if (typeof type === "string") {
-            const container = this.#_storage[type] as unknown as Container;
+        const serialized = this.value.toJSON() as Record<string, unknown>;
 
-            return container instanceof LoroText
-                ? container.toString()
-                : container instanceof LoroCounter
-                  ? container.value
-                  : container.toJSON!();
+        if (typeof type === "string") {
+            const container = this.#_storage[type] as unknown as Container | undefined;
+
+            if (container) {
+                return container instanceof LoroText
+                    ? container.toString()
+                    : container instanceof LoroCounter
+                      ? container.value
+                      : container.toJSON!();
+            }
+
+            return (serialized[type] ?? null) as InferCrdtJson<TStorage[TKey]>;
         }
 
-        return Object.entries(this.#_storage).reduce((acc, [key, value]) => {
-            Object.assign(acc, {
-                [key]: value instanceof LoroText ? value.toString() : value.toJSON!(),
-            });
+        const { [PLUV_ID_FIELD]: _pluvId, ...json } = serialized;
 
-            return acc;
-        }, {} as InferCrdtJson<TStorage>);
+        return json as InferCrdtJson<TStorage>;
     }
 
     public isDirty(): boolean {

--- a/packages/crdt-yjs/src/doc/CrdtYjsDoc.ts
+++ b/packages/crdt-yjs/src/doc/CrdtYjsDoc.ts
@@ -8,6 +8,9 @@ import type { CrdtDocLike } from "@pluv/types";
 import { fromUint8Array, toUint8Array } from "js-base64";
 import {
     AbstractType,
+    ContentEmbed,
+    ContentFormat,
+    ContentString,
     UndoManager,
     Array as YArray,
     Doc as YDoc,
@@ -227,12 +230,17 @@ export class CrdtYjsDoc<TStorage extends Record<string, YjsType<any, any>>> impl
     public toJson(): InferCrdtJson<TStorage>;
     public toJson<TKey extends keyof TStorage>(type: TKey): InferCrdtJson<TStorage[TKey]>;
     public toJson<TKey extends keyof TStorage>(type?: TKey) {
-        if (typeof type === "string") return this.#_storage[type].toJSON();
+        if (typeof type === "string") {
+            const shared = this.#_storage[type];
 
-        return Object.entries(this.#_storage).reduce(
-            (acc, [key, value]) => ({ ...(acc as any), [key]: value.toJSON() }),
-            {} as InferCrdtJson<TStorage>,
-        );
+            if (shared) return shared.toJSON();
+
+            const fromDoc = this.value.share.get(type);
+
+            return (this.#_toJsonFromShare(type, fromDoc) ?? null) as InferCrdtJson<TStorage[TKey]>;
+        }
+
+        return this.#_toJsonFromDoc();
     }
 
     public undo(): this {
@@ -246,5 +254,67 @@ export class CrdtYjsDoc<TStorage extends Record<string, YjsType<any, any>>> impl
         const id = typeof crypto !== "undefined" ? crypto.randomUUID() : Math.random().toString();
 
         text.insert(0, id);
+    }
+
+    #_toJsonFromDoc(): InferCrdtJson<TStorage> {
+        const json = {} as InferCrdtJson<TStorage>;
+
+        this.value.share.forEach((sharedType, key) => {
+            if (key === PLUV_ID_FIELD) return;
+
+            Object.assign(json, { [key]: this.#_toJsonFromShare(key, sharedType) });
+        });
+
+        return json;
+    }
+
+    #_toJsonFromShare(key: string, sharedType: AbstractType<any> | undefined): unknown {
+        if (!sharedType) return null;
+
+        if (
+            sharedType instanceof YXmlElement ||
+            sharedType instanceof YXmlFragment ||
+            sharedType instanceof YXmlText ||
+            sharedType instanceof YText ||
+            sharedType instanceof YArray ||
+            sharedType instanceof YMap
+        ) {
+            return sharedType.toJSON();
+        }
+
+        const start = (
+            sharedType as AbstractType<any> & {
+                _start?: { content?: object } | null;
+                _map?: Map<string, unknown>;
+            }
+        )._start;
+        const map = (
+            sharedType as AbstractType<any> & {
+                _map?: Map<string, unknown>;
+            }
+        )._map;
+        const content = start?.content ?? null;
+
+        if (
+            content instanceof ContentString ||
+            content instanceof ContentEmbed ||
+            content instanceof ContentFormat
+        ) {
+            return this.value.getText(key).toJSON();
+        }
+
+        if (map && map.size > 0 && start) {
+            return this.value.getXmlElement(key).toJSON();
+        }
+
+        if (start) {
+            return this.value.getArray(key).toJSON();
+        }
+
+        if (map && map.size > 0) {
+            return this.value.getMap(key).toJSON();
+        }
+
+        return {};
     }
 }

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -146,8 +146,7 @@ export class IORoom<
     >();
     private readonly _userSessionss = new Map<[userId: string][0], Set<[sessionId: string][0]>>();
 
-    private _wasDocEmptyOnInit: boolean = true;
-    private _storageInitializedViaSession: boolean = false;
+    private _storageSeeded: boolean = false;
 
     /**
      * @ignore
@@ -679,24 +678,22 @@ export class IORoom<
 
             if (!!loadedState && !this._docFactory.isEmpty(loadedState)) {
                 doc.applyEncodedState({ update: loadedState });
-
-                // Storage loaded from getInitialStorage is already initialized. Without this,
-                // _wasDocEmptyOnInit is false and onStorageDestroyed can never fire again, so
-                // the external store keeps whatever snapshot it had.
-                this._storageInitializedViaSession = true;
+                this._storageSeeded = true;
             }
         }
 
         if (typeof encodedState === "string") {
             doc.applyEncodedState({ update: encodedState });
 
-            // If we loaded storage from persistence and it's non-empty, storage was previously initialized.
-            // This handles hibernation wake-up: restore the initialization state so that onStorageDestroyed
-            // will fire correctly when the room is destroyed.
             if (!doc.isEmpty()) {
-                this._storageInitializedViaSession = true;
+                this._storageSeeded = true;
             }
         }
+
+        const initialized = this._docFactory.getInitialized();
+
+        doc.rebuildStorage(initialized.get());
+        initialized.destroy();
 
         return doc;
     }
@@ -820,9 +817,6 @@ export class IORoom<
 
             const doc = await this._getInitialDoc();
 
-            // Track if doc was empty when room was first initialized
-            this._wasDocEmptyOnInit = doc.isEmpty();
-
             const uninitialize = async (): Promise<void> => {
                 // Teardown clears the doc partway through, so re-entering would persist that
                 // cleared doc over the room's real content.
@@ -839,10 +833,9 @@ export class IORoom<
 
                     // This room has held content, so an unwritten doc here was cleared by a
                     // teardown rather than by the user.
-                    const shouldDestroyStorage =
-                        this._storageInitializedViaSession && resolvedDoc.isDirty();
+                    const shouldDestroyStorage = this._storageSeeded && resolvedDoc.isDirty();
 
-                    if (this._storageInitializedViaSession && !shouldDestroyStorage) {
+                    if (this._storageSeeded && !shouldDestroyStorage) {
                         this._logDebug(
                             colors.blue(
                                 `Refusing to persist an unwritten document for room: ${this.id}`,
@@ -850,7 +843,7 @@ export class IORoom<
                         );
                     }
 
-                    this._storageInitializedViaSession = false;
+                    this._storageSeeded = false;
 
                     resolvedDoc.destroy();
                     this._doc = Promise.resolve(this._docFactory.getEmpty());
@@ -929,6 +922,7 @@ export class IORoom<
             };
 
             const [doc, context] = await Promise.all([this._doc, this._getContext()]);
+            const room = this;
             const eventContext: EventResolverContext<
                 EventResolverKind,
                 TPlatform,
@@ -954,6 +948,12 @@ export class IORoom<
                 room: this.id,
                 session,
                 sessions,
+                get storageSeeded() {
+                    return room._storageSeeded;
+                },
+                set storageSeeded(value: boolean) {
+                    room._storageSeeded = value;
+                },
                 time: new Date().getTime(),
             };
 
@@ -1061,10 +1061,6 @@ export class IORoom<
 
                 await Promise.all([handleBroadcast(), handleSelf(), handleSync()]);
             });
-
-            // After processing messages that might update storage (like $initializeSession),
-            // check if storage was initialized via initializeSession
-            await this._checkStorageInitializedViaSession();
         };
     }
 
@@ -1133,19 +1129,6 @@ export class IORoom<
         this._userSessionss.delete(userId);
 
         return set;
-    }
-
-    private async _checkStorageInitializedViaSession(): Promise<void> {
-        if (this._storageInitializedViaSession) return;
-
-        // Only mark as initialized if:
-        // 1. Doc was empty when room was first initialized
-        // 2. Doc is now non-empty
-        // 3. At least one session has been registered
-        const doc = await this._doc;
-        if (this._wasDocEmptyOnInit && !doc.isEmpty() && this._sessions.size > 0) {
-            this._storageInitializedViaSession = true;
-        }
     }
 
     private async _sendMessage(
@@ -1238,6 +1221,7 @@ export class IORoom<
         if (typeof connectionId !== "string") return;
 
         const [doc, context] = await Promise.all([this._doc, this._getContext()]);
+        const room = this;
         const resolverCtx: EventResolverContext<"sync", TPlatform, TAuthorize, TContext> = {
             context,
             doc,
@@ -1254,6 +1238,12 @@ export class IORoom<
             room: this.id,
             session: null,
             sessions: this._getSessions(),
+            get storageSeeded() {
+                return room._storageSeeded;
+            },
+            set storageSeeded(value: boolean) {
+                room._storageSeeded = value;
+            },
             time: new Date().getTime(),
         };
 

--- a/packages/io/src/PluvServer.ts
+++ b/packages/io/src/PluvServer.ts
@@ -195,23 +195,14 @@ export class PluvServer<
                         },
                     };
                 })
-                .self(async (data, { context, doc, platform, room, session }) => {
-                    const oldState = await platform.persistence.getStorageState(room);
+                .self(async (data, event) => {
+                    const { context, doc, platform, room, session } = event;
                     /**
-                     * !HACK
                      * @description This is the frontend's initialStorage. We only want to
-                     * apply this if the server's storage is empty (i.e. no initial storage
-                     * has been applied)
+                     * apply this if the server has not already been seeded (persistence,
+                     * getInitialStorage, or an earlier client seed).
                      */
                     const update = (data as any)?.update as Maybe<string>;
-
-                    if (!oldState) {
-                        const loadedState = await this._getInitialStorage({ context, room });
-
-                        if (!!loadedState && !this._docFactory.isEmpty(loadedState)) {
-                            doc.applyEncodedState({ update: loadedState });
-                        }
-                    }
 
                     /**
                      * @description Storage was already initialized. Don't overwrite the current
@@ -219,7 +210,7 @@ export class PluvServer<
                      * is without changes.
                      * @date May 7, 2025
                      */
-                    if (!doc.isEmpty()) {
+                    if (event.storageSeeded) {
                         const encodedState = doc.getEncodedState();
 
                         return {
@@ -243,6 +234,8 @@ export class PluvServer<
                         ) {
                             throw new Error("Storage has exceeded the size limit");
                         }
+
+                        event.storageSeeded = true;
 
                         await platform.persistence
                             .setStorageState(room, encodedState)
@@ -322,7 +315,7 @@ export class PluvServer<
                     const origin = (data as any)?.origin as Maybe<string>;
                     const update: string | null = (data as any)?.update ?? null;
 
-                    if (origin === "$initialized" && Object.keys(doc.toJson()).length) return {};
+                    if (origin === "$initialized") return {};
 
                     const updated = update === null ? doc : doc.applyEncodedState({ update });
                     const encodedState = updated.getEncodedState();

--- a/packages/io/src/types.ts
+++ b/packages/io/src/types.ts
@@ -54,6 +54,7 @@ export interface EventResolverContext<
     platform: TPlatform;
     presence: JsonObject | null;
     room: string;
+    storageSeeded: boolean;
     session: TKind extends "sync"
         ? WebSocketSession<TAuthorize> | null
         : WebSocketSession<TAuthorize>;

--- a/tests/unit/src/CloudflarePlatform.persistence.test.ts
+++ b/tests/unit/src/CloudflarePlatform.persistence.test.ts
@@ -1,7 +1,16 @@
+import { yjs } from "@pluv/crdt-yjs";
+import { createIO } from "@pluv/io";
 import { PersistenceCloudflareTransactionalStorage } from "@pluv/persistence-cloudflare-transactional-storage";
 import { platformCloudflare } from "@pluv/platform-cloudflare";
 import { beforeAll, describe, expect, it } from "vitest";
-import { createMockDurableObjectState, TestPersistence } from "./__utils__";
+import {
+    createMockDurableObjectState,
+    deferred,
+    encodedStateWithContent,
+    TestPersistence,
+    TestPlatform,
+    TestSocket,
+} from "./__utils__";
 
 const LATEST_SNAPSHOT = "snapshot-after-second-edit";
 
@@ -54,5 +63,62 @@ describe("CloudflarePlatform persistence", () => {
 
         expect(initialized.persistence).toBeInstanceOf(TestPersistence);
         await expect(initialized.persistence.getStorageState("home-page")).resolves.toBe("custom");
+    });
+
+    it("loads Durable Object storage after wake instead of webhook or client seed", async () => {
+        const { platform } = platformCloudflare();
+        const state = createMockDurableObjectState();
+        const roomContext = { env: {}, state };
+        const roomId = "home-page";
+        const doSnapshot = encodedStateWithContent("do");
+        const webhook = deferred<string | null>();
+        let reads = 0;
+
+        const beforeHibernation = platform().initialize({ roomContext });
+
+        await beforeHibernation.persistence.setStorageState(roomId, doSnapshot);
+
+        const afterHibernation = platform().initialize({ roomContext });
+        const io = createIO({
+            crdt: yjs,
+            platform: () =>
+                new TestPlatform({
+                    mode: "detached",
+                    persistence: afterHibernation.persistence,
+                }),
+        });
+        const server = io.server({
+            getInitialStorage: () => {
+                reads += 1;
+
+                return webhook.promise;
+            },
+        });
+        const room = server.createRoom(roomId, { env: {}, state } as never);
+        const socket = new TestSocket("session-1");
+
+        await room.register(socket);
+        expect(reads).toBe(0);
+
+        webhook.resolve(encodedStateWithContent("webhook"));
+        await room.onMessage(socket)({
+            data: JSON.stringify({
+                type: "$initializeSession",
+                data: { presence: {}, update: encodedStateWithContent("client") },
+            }),
+        });
+
+        const received = [...socket.messages]
+            .reverse()
+            .find((message) => message.type === "$storageReceived");
+        const doc = yjs
+            .doc(() => ({}))
+            .getEmpty()
+            .applyEncodedState({ update: received?.data.state });
+
+        expect((doc.toJson() as { content?: string }).content).toBe("do");
+        expect(reads).toBe(0);
+
+        doc.destroy();
     });
 });

--- a/tests/unit/src/IORoom.storageInit.test.ts
+++ b/tests/unit/src/IORoom.storageInit.test.ts
@@ -1,0 +1,323 @@
+import { loro } from "@pluv/crdt-loro";
+import { yjs } from "@pluv/crdt-yjs";
+import { createIO } from "@pluv/io";
+import { LoroDoc } from "loro-crdt";
+import { applyUpdate, Doc as YDoc, encodeStateAsUpdate, encodeStateVector } from "yjs";
+import { describe, expect, it } from "vitest";
+import {
+    deferred,
+    encodedLoroStateWithContent,
+    encodedStateWithContent,
+    TestPersistence,
+    TestPlatform,
+    TestSocket,
+    tick,
+} from "./__utils__";
+
+type Room = {
+    onMessage: (socket: TestSocket) => (event: { data: string }) => Promise<void>;
+    register: (socket: TestSocket) => Promise<void>;
+};
+
+const appendYjs = (encodedState: string, text: string): string => {
+    const doc = new YDoc();
+
+    applyUpdate(doc, Buffer.from(encodedState, "base64"));
+
+    const stateVector = encodeStateVector(doc);
+    const content = doc.getText("content");
+
+    content.insert(content.length, text);
+
+    return Buffer.from(encodeStateAsUpdate(doc, stateVector)).toString("base64");
+};
+
+const appendLoro = (encodedState: string, text: string): string => {
+    const doc = new LoroDoc();
+
+    doc.import(Buffer.from(encodedState, "base64"));
+
+    const content = doc.getText("content");
+
+    content.insert(content.length, text);
+    doc.commit();
+
+    return Buffer.from(doc.export({ mode: "update" })).toString("base64");
+};
+
+const lastMessage = (socket: TestSocket, type: string): { type: string; data: any } => {
+    const message = [...socket.messages].reverse().find((entry) => entry.type === type);
+
+    if (!message) throw new Error(`Missing ${type} message`);
+
+    return message;
+};
+
+const initializeSession = async (room: Room, socket: TestSocket, update: string): Promise<void> => {
+    await room.onMessage(socket)({
+        data: JSON.stringify({
+            type: "$initializeSession",
+            data: { presence: {}, update },
+        }),
+    });
+};
+
+const updateStorage = async (
+    room: Room,
+    socket: TestSocket,
+    origin: string | null,
+    update: string,
+): Promise<void> => {
+    await room.onMessage(socket)({
+        data: JSON.stringify({
+            type: "$updateStorage",
+            data: { origin, update },
+        }),
+    });
+};
+
+class GatedPersistence extends TestPersistence {
+    public readonly persist = deferred<void>();
+
+    public override setStorageState(room: string, state: string): Promise<void> {
+        return this.persist.promise.then(() => super.setStorageState(room, state));
+    }
+}
+
+const scenarios = [
+    {
+        name: "yjs",
+        crdt: yjs,
+        encode: encodedStateWithContent,
+        decode: (encodedState: string) => {
+            const doc = yjs
+                .doc(() => ({}))
+                .getEmpty()
+                .applyEncodedState({ update: encodedState });
+            const content = (doc.toJson() as { content?: string }).content ?? "";
+
+            doc.destroy();
+
+            return content;
+        },
+        append: appendYjs,
+    },
+    {
+        name: "loro",
+        crdt: loro,
+        encode: encodedLoroStateWithContent,
+        decode: (encodedState: string) => {
+            const doc = loro
+                .doc(() => ({}))
+                .getEmpty()
+                .applyEncodedState({ update: encodedState });
+            const content = (doc.toJson() as { content?: string }).content ?? "";
+
+            doc.destroy();
+
+            return content;
+        },
+        append: appendLoro,
+    },
+];
+
+describe.each(scenarios)("$name IORoom storage init", ({ append, crdt, decode, encode }) => {
+    const createRoom = (config: {
+        getInitialStorage: () => Promise<string | null>;
+        persistence?: TestPersistence;
+        roomId?: string;
+    }) => {
+        const persistence = config.persistence ?? new TestPersistence();
+        const io = createIO({
+            crdt,
+            platform: () => new TestPlatform({ mode: "detached", persistence }),
+        });
+        const server = io.server({ getInitialStorage: config.getInitialStorage });
+        const room = server.createRoom(config.roomId ?? "storage-init");
+
+        return { persistence, room };
+    };
+
+    it("keeps delayed webhook state instead of a later client seed", async () => {
+        const webhook = deferred<string | null>();
+        let reads = 0;
+        const { room } = createRoom({
+            getInitialStorage: () => {
+                reads += 1;
+
+                return webhook.promise;
+            },
+        });
+        const socket = new TestSocket("session-1");
+        const registration = room.register(socket);
+
+        await tick();
+        expect(reads).toBe(1);
+
+        webhook.resolve(encode("server"));
+        await registration;
+        await initializeSession(room, socket, encode("client"));
+
+        expect(decode(lastMessage(socket, "$storageReceived").data.state)).toBe("server");
+        expect(lastMessage(socket, "$storageReceived").data.changeKind).toBe("unchanged");
+        expect(reads).toBe(1);
+    });
+
+    it("lets persistence beat a delayed webhook and client seed", async () => {
+        const persistence = new TestPersistence();
+        const webhook = deferred<string | null>();
+        let reads = 0;
+
+        await persistence.setStorageState("storage-init", encode("do"));
+
+        const { room } = createRoom({
+            getInitialStorage: () => {
+                reads += 1;
+
+                return webhook.promise;
+            },
+            persistence,
+        });
+        const socket = new TestSocket("session-1");
+
+        await room.register(socket);
+        expect(reads).toBe(0);
+
+        webhook.resolve(encode("webhook"));
+        await initializeSession(room, socket, encode("client"));
+
+        expect(decode(lastMessage(socket, "$storageReceived").data.state)).toBe("do");
+        expect(reads).toBe(0);
+    });
+
+    it("allows a client seed when the delayed webhook is null", async () => {
+        const webhook = deferred<string | null>();
+        const { persistence, room } = createRoom({
+            getInitialStorage: () => webhook.promise,
+        });
+        const socket = new TestSocket("session-1");
+        const registration = room.register(socket);
+
+        await tick();
+        webhook.resolve(null);
+        await registration;
+        await initializeSession(room, socket, encode("client"));
+
+        expect(lastMessage(socket, "$storageReceived").data.changeKind).toBe("initialized");
+        expect(decode(lastMessage(socket, "$storageReceived").data.state)).toBe("client");
+        expect(decode((await persistence.getStorageState("storage-init")) ?? "")).toBe("client");
+    });
+
+    it("hydrates two overlapping first connections from one webhook fetch", async () => {
+        const webhook = deferred<string | null>();
+        let reads = 0;
+        const { room } = createRoom({
+            getInitialStorage: () => {
+                reads += 1;
+
+                return webhook.promise;
+            },
+        });
+        const first = new TestSocket("session-1");
+        const second = new TestSocket("session-2");
+        const registrations = Promise.all([room.register(first), room.register(second)]);
+
+        await tick();
+        expect(reads).toBe(1);
+
+        webhook.resolve(encode("server"));
+        await registrations;
+        await Promise.all([
+            initializeSession(room, first, encode("client-a")),
+            initializeSession(room, second, encode("client-b")),
+        ]);
+
+        expect(decode(lastMessage(first, "$storageReceived").data.state)).toBe("server");
+        expect(decode(lastMessage(second, "$storageReceived").data.state)).toBe("server");
+        expect(lastMessage(first, "$storageReceived").data.changeKind).toBe("unchanged");
+        expect(lastMessage(second, "$storageReceived").data.changeKind).toBe("unchanged");
+        expect(reads).toBe(1);
+    });
+
+    it("ignores a second vacant client seed while the first persist is in flight", async () => {
+        const persistence = new GatedPersistence();
+        const { room } = createRoom({
+            getInitialStorage: () => Promise.resolve(null),
+            persistence,
+        });
+        const first = new TestSocket("session-1");
+        const second = new TestSocket("session-2");
+
+        await Promise.all([room.register(first), room.register(second)]);
+
+        const firstInit = initializeSession(room, first, encode("alpha"));
+        const secondInit = initializeSession(room, second, encode("beta"));
+
+        await tick();
+
+        expect(lastMessage(second, "$storageReceived").data.changeKind).toBe("unchanged");
+        expect(decode(lastMessage(second, "$storageReceived").data.state)).toBe("alpha");
+
+        persistence.persist.resolve();
+        await Promise.all([firstInit, secondInit]);
+
+        expect(lastMessage(first, "$storageReceived").data.changeKind).toBe("initialized");
+        expect(decode(lastMessage(first, "$storageReceived").data.state)).toBe("alpha");
+        expect(decode((await persistence.getStorageState("storage-init")) ?? "")).toBe("alpha");
+    });
+
+    it("does not apply $updateStorage origin $initialized after a claimed load", async () => {
+        const { persistence, room } = createRoom({
+            getInitialStorage: () => Promise.resolve(encode("server")),
+        });
+        const socket = new TestSocket("session-1");
+
+        await room.register(socket);
+        await initializeSession(room, socket, encode("client"));
+        await updateStorage(room, socket, "$initialized", encode("client"));
+
+        expect(decode(lastMessage(socket, "$storageReceived").data.state)).toBe("server");
+        expect(await persistence.getStorageState("storage-init")).toBeNull();
+    });
+
+    it("still applies $updateStorage origin null", async () => {
+        const { persistence, room } = createRoom({
+            getInitialStorage: () => Promise.resolve(encode("server")),
+        });
+        const socket = new TestSocket("session-1");
+
+        await room.register(socket);
+        await initializeSession(room, socket, encode("client"));
+
+        const base = lastMessage(socket, "$storageReceived").data.state as string;
+
+        await updateStorage(room, socket, null, append(base, " live"));
+
+        expect(decode((await persistence.getStorageState("storage-init")) ?? "")).toBe(
+            "server live",
+        );
+    });
+
+    it("merges two overlapping live origin-null updates", async () => {
+        const { persistence, room } = createRoom({
+            getInitialStorage: () => Promise.resolve(encode("base")),
+        });
+        const first = new TestSocket("session-1");
+        const second = new TestSocket("session-2");
+
+        await Promise.all([room.register(first), room.register(second)]);
+        await initializeSession(room, first, encode("client"));
+
+        const base = lastMessage(first, "$storageReceived").data.state as string;
+
+        await Promise.all([
+            updateStorage(room, first, null, append(base, "A")),
+            updateStorage(room, second, null, append(base, "B")),
+        ]);
+
+        const stored = decode((await persistence.getStorageState("storage-init")) ?? "");
+
+        expect(stored).toContain("A");
+        expect(stored).toContain("B");
+    });
+});

--- a/tests/unit/src/__utils__/helpers.ts
+++ b/tests/unit/src/__utils__/helpers.ts
@@ -1,3 +1,4 @@
+import { loro } from "@pluv/crdt-loro";
 import { Doc as YDoc, encodeStateAsUpdate } from "yjs";
 
 export interface Deferred<T> {
@@ -38,6 +39,15 @@ export const encodedStateWithContent = (text: string): string => {
     doc.getText("content").insert(0, text);
 
     return Buffer.from(encodeStateAsUpdate(doc)).toString("base64");
+};
+
+export const encodedLoroStateWithContent = (text: string): string => {
+    const doc = loro.doc((t) => ({ content: t.text("content", text) })).getInitialized();
+    const encodedState = doc.getEncodedState();
+
+    doc.destroy();
+
+    return encodedState;
 };
 
 /** Yjs-specific. A pristine Y.Doc encodes to the 2-byte "AAA=" payload that wiped storage. */

--- a/tests/unit/src/__utils__/index.ts
+++ b/tests/unit/src/__utils__/index.ts
@@ -1,5 +1,12 @@
 export type { Deferred } from "./helpers";
-export { deferred, encodedStateWithContent, isEmptyEncodedState, tick, waitUntil } from "./helpers";
+export {
+    deferred,
+    encodedLoroStateWithContent,
+    encodedStateWithContent,
+    isEmptyEncodedState,
+    tick,
+    waitUntil,
+} from "./helpers";
 export { TestPersistence } from "./TestPersistence";
 export { TestPlatform } from "./TestPlatform";
 export type { TestPlatformConfig } from "./TestPlatform";

--- a/tests/unit/src/documentToJson.test.ts
+++ b/tests/unit/src/documentToJson.test.ts
@@ -1,0 +1,50 @@
+import { loro } from "@pluv/crdt-loro";
+import { yjs } from "@pluv/crdt-yjs";
+import { describe, expect, it } from "vitest";
+
+const AUTHORED_CONTENT = "authored app json";
+
+const scenarios = [
+    {
+        name: "yjs",
+        empty: () => yjs.doc(() => ({})).getEmpty(),
+        authored: () =>
+            yjs.doc((t) => ({ content: t.text("content", AUTHORED_CONTENT) })).getInitialized(),
+        encoded: () =>
+            yjs
+                .doc((t) => ({ content: t.text("content", AUTHORED_CONTENT) }))
+                .getInitialized()
+                .getEncodedState(),
+        keyed: (doc: { toJson: (key: "content") => unknown }) => doc.toJson("content"),
+    },
+    {
+        name: "loro",
+        empty: () => loro.doc(() => ({})).getEmpty(),
+        authored: () =>
+            loro.doc((t) => ({ content: t.text("content", AUTHORED_CONTENT) })).getInitialized(),
+        encoded: () =>
+            loro
+                .doc((t) => ({ content: t.text("content", AUTHORED_CONTENT) }))
+                .getInitialized()
+                .getEncodedState(),
+        keyed: (doc: { toJson: (key: "content") => unknown }) => doc.toJson("content"),
+    },
+] as const;
+
+describe.each(scenarios)("$name toJson", ({ authored, empty, encoded, keyed }) => {
+    it("serializes schema-initialized documents from the underlying doc", () => {
+        const doc = authored();
+
+        expect(doc.toJson()).toEqual({ content: AUTHORED_CONTENT });
+        expect(keyed(doc)).toBe(AUTHORED_CONTENT);
+        expect(doc.toJson()).not.toHaveProperty("__$pluv");
+    });
+
+    it("serializes an empty factory after applyEncodedState", () => {
+        const doc = empty().applyEncodedState({ update: encoded() });
+
+        expect(doc.toJson()).toEqual({ content: AUTHORED_CONTENT });
+        expect((doc.toJson() as { content?: string }).content).toBe(AUTHORED_CONTENT);
+        expect(doc.toJson()).not.toHaveProperty("__$pluv");
+    });
+});


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/main/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Loaded room storage is no longer overwritten when another client joins with `initialStorage`.

- Persistence and `getInitialStorage` take priority over a client's `initialStorage`. Joining an already-seeded room leaves that storage unchanged.
- The client's `$initialized` storage echo is ignored, so a local snapshot cannot replace server state after load.
- Two clients connecting at once only load `getInitialStorage` once. If they both try to seed an empty room, only the first `initialStorage` is applied.
- Yjs and Loro `toJson()` now return the document's actual contents, including when storage was loaded from an encoded snapshot instead of a schema.