### PR TITLE
fix: initial presence not being saved on the server

### DIFF
--- a/.changeset/quiet-pumas-remain.md
+++ b/.changeset/quiet-pumas-remain.md
@@ -1,0 +1,7 @@
+---
+"@pluv/io": patch
+---
+
+Fix initial presence not being saved on the server.
+
+Late joiners could see other users with empty/default presence, and later presence patches could drop fields that were only set when the session started.

--- a/packages/io/src/PluvServer.ts
+++ b/packages/io/src/PluvServer.ts
@@ -178,20 +178,20 @@ export class PluvServer<
                 return { $othersReceived: { others } };
             }),
             $initializeSession: this._procedure
-                .broadcast((data, { session }) => {
-                    const presence = (data as any)?.presence;
-                    const timers = session.timers;
+                .broadcast((data, event) => {
+                    const presence = (data as any)?.presence ?? null;
+                    const { session } = event;
 
                     if (!session) return {};
 
-                    session.presence = presence;
+                    event.presence = presence;
 
                     return {
                         $userJoined: {
                             connectionId: session.id,
                             user: session.user,
                             presence,
-                            timers: { presence: timers.presence },
+                            timers: { presence: session.webSocket.state.timers.presence },
                         },
                     };
                 })

--- a/tests/unit/src/IORoom.presence.test.ts
+++ b/tests/unit/src/IORoom.presence.test.ts
@@ -1,0 +1,113 @@
+import { createIO } from "@pluv/io";
+import { describe, expect, it } from "vitest";
+import { TestPlatform, TestSocket } from "./__utils__";
+
+type Room = {
+    onMessage: (socket: TestSocket) => (event: { data: string }) => Promise<void>;
+    register: (socket: TestSocket) => Promise<void>;
+};
+
+const lastMessage = (socket: TestSocket, type: string): { type: string; data: any } => {
+    const message = [...socket.messages].reverse().find((entry) => entry.type === type);
+
+    if (!message) throw new Error(`Missing ${type} message`);
+
+    return message;
+};
+
+const initializeSession = async (
+    room: Room,
+    socket: TestSocket,
+    presence: Record<string, unknown>,
+): Promise<void> => {
+    await room.onMessage(socket)({
+        data: JSON.stringify({
+            type: "$initializeSession",
+            data: { presence, update: null },
+        }),
+    });
+};
+
+const updatePresence = async (
+    room: Room,
+    socket: TestSocket,
+    presence: Record<string, unknown>,
+): Promise<void> => {
+    await room.onMessage(socket)({
+        data: JSON.stringify({
+            type: "$updatePresence",
+            data: { presence },
+        }),
+    });
+};
+
+const getOthers = async (room: Room, socket: TestSocket): Promise<void> => {
+    await room.onMessage(socket)({
+        data: JSON.stringify({
+            type: "$getOthers",
+            data: {},
+        }),
+    });
+};
+
+describe("IORoom presence", () => {
+    const createRoom = (roomId: string = "presence") => {
+        const io = createIO({
+            platform: () => new TestPlatform({ mode: "detached" }),
+        });
+        const server = io.server();
+        const room = server.createRoom(roomId);
+
+        return room;
+    };
+
+    it("persists initialize presence for later $getOthers and partial patches", async () => {
+        const room = createRoom();
+        const first = new TestSocket("session-1");
+        const second = new TestSocket("session-2");
+
+        await room.register(first);
+        await initializeSession(room, first, { cursor: 1, name: "ada" });
+
+        await room.register(second);
+        await initializeSession(room, second, { cursor: 0, name: "bob" });
+        await getOthers(room, second);
+
+        expect(lastMessage(second, "$othersReceived").data.others["session-1"].presence).toEqual({
+            cursor: 1,
+            name: "ada",
+        });
+
+        await updatePresence(room, first, { cursor: 2 });
+
+        expect(lastMessage(second, "$presenceUpdated").data.presence).toEqual({
+            cursor: 2,
+            name: "ada",
+        });
+
+        await getOthers(room, second);
+
+        expect(lastMessage(second, "$othersReceived").data.others["session-1"].presence).toEqual({
+            cursor: 2,
+            name: "ada",
+        });
+    });
+
+    it("still broadcasts $userJoined with the initialize presence payload", async () => {
+        const room = createRoom("presence-join");
+        const first = new TestSocket("session-1");
+        const second = new TestSocket("session-2");
+
+        await room.register(first);
+        await initializeSession(room, first, { cursor: 0, name: "ada" });
+
+        await room.register(second);
+        await initializeSession(room, second, { cursor: 9, name: "bob" });
+
+        expect(lastMessage(first, "$userJoined").data).toMatchObject({
+            connectionId: "session-2",
+            presence: { cursor: 9, name: "bob" },
+        });
+        expect(typeof lastMessage(first, "$userJoined").data.timers.presence).toBe("number");
+    });
+});


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/main/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fix initial presence not being saved on the server.

Late joiners could see other users with empty/default presence, and later presence patches could drop fields that were only set when the session started.