### PR TITLE
Send $error when procedure resolvers or size limits throw.

### DIFF
--- a/.changeset/brave-foxes-reply.md
+++ b/.changeset/brave-foxes-reply.md
@@ -1,0 +1,7 @@
+---
+"@pluv/io": patch
+---
+
+Surface procedure and size-limit failures to clients as `$error`.
+
+If a custom event handler threw, or presence/storage exceeded its size limit, the server used to fail silently from the client's point of view. Those errors now arrive on the same `$error` path already used for invalid input.

--- a/.cursor/rules/changesets.mdc
+++ b/.cursor/rules/changesets.mdc
@@ -1,0 +1,51 @@
+---
+description: How to write changesets for @pluv packages — users first, maintainers second
+globs: .changeset/**/*.md
+alwaysApply: false
+---
+
+# Changesets
+
+Write for **library users** first (app developers reading the changelog). Maintainers second.
+
+## Do
+
+- Lead with the user-visible outcome: what works now, what stopped breaking, what they can rely on
+- Name the symptom someone would hit in their app (late joiners, silent failures, wrong presence, etc.)
+- Keep internal detail brief and after the user-facing summary
+- Prefer plain language over event/protocol names unless users actually handle those APIs
+
+## Don't
+
+- Lead with implementation (“persist onto websocket state”, “wrap Promise.all in try/catch”)
+- Lead with internal symbols unless they are part of the public API users call or listen for
+- Write as a PR description or commit body dump
+
+## Examples
+
+```md
+<!-- ❌ Maintainer-first -->
+Persist `$initializeSession` presence onto websocket state so later `$getOthers`
+and `$updatePresence` patches keep the initialized fields.
+
+<!-- ✅ User-first -->
+Fix initial presence not being saved on the server.
+
+Late joiners could see other users with empty/default presence, and later
+presence patches could drop fields that were only set when the session started.
+```
+
+```md
+<!-- ❌ Maintainer-first -->
+Send `$error` when a procedure resolver or size-limit check throws, instead of
+leaving an unhandled rejection.
+
+<!-- ✅ User-first -->
+Surface procedure and size-limit failures to clients as `$error`.
+
+If a custom event handler threw, or presence/storage exceeded its size limit,
+the server used to fail silently from the client's point of view. Those errors
+now arrive on the same `$error` path already used for invalid input.
+```
+
+`$error` is fine to name when users already receive that event; still explain the *experience* first.

--- a/.cursor/rules/conventional-commits.mdc
+++ b/.cursor/rules/conventional-commits.mdc
@@ -31,7 +31,7 @@ type(optional-scope): short summary
 | `test` | Tests only |
 | `ci` | CI config |
 
-Automated/release commits like `Version Packages` come from changesets — don’t imitate those by hand.
+Release PRs from `changesets/action` use `chore: version packages` (see `.github/workflows/release.yml`). Don’t hand-write those; don’t revert them to bare `Version Packages`.
 
 ## Examples from this repo
 
@@ -44,6 +44,7 @@ feat: export inner types
 chore: bump deps
 chore(deps): update dependency oxfmt to ^0.67.0
 chore: add changeset
+chore: version packages
 ```
 
 ## Avoid

--- a/.cursor/rules/conventional-commits.mdc
+++ b/.cursor/rules/conventional-commits.mdc
@@ -1,0 +1,65 @@
+---
+description: Conventional commit message format matching this repo’s history and Commitizen setup
+alwaysApply: true
+---
+
+# Conventional commits
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/) as used in this repo (`pnpm commit` / Commitizen with `cz-conventional-changelog`). See also [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Format
+
+```
+type(optional-scope): short summary
+```
+
+- **type**: lowercase (`feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `perf`, `build`, `style`)
+- **scope** (optional): package or area without `@pluv/` — e.g. `io`, `client`, `platform-pluv`, `deps`
+- **summary**: imperative, concise; start lowercase; no trailing period; focus on *why/what changed for the project*, not a file list
+- Body (optional): one blank line after summary; wrap sensibly; explain motivation when useful
+- Do **not** append `(#123)` yourself — GitHub adds that on merge when relevant
+
+## Types this repo uses most
+
+| Type | Use for |
+|------|---------|
+| `fix` | Bug fixes (correctness, regressions) |
+| `feat` | New user-facing capability |
+| `chore` | Tooling, deps bumps, repo hygiene, changesets-only commits |
+| `docs` | Documentation only |
+| `refactor` | Internal change with no intended behavior change |
+| `test` | Tests only |
+| `ci` | CI config |
+
+Automated/release commits like `Version Packages` come from changesets — don’t imitate those by hand.
+
+## Examples from this repo
+
+```text
+fix: initial presence not being saved on the server
+fix(io): preserve healthy hibernated sockets
+fix(client): return null from getStorage while unavailable
+feat(platform-pluv): allow custom fetch
+feat: export inner types
+chore: bump deps
+chore(deps): update dependency oxfmt to ^0.67.0
+chore: add changeset
+```
+
+## Avoid
+
+```text
+# ❌ Non-conventional / wrong case
+Fix/io initial storage seed
+Fixed the presence bug
+WIP
+update stuff
+
+# ❌ Scope with package prefix
+fix(@pluv/io): ...
+
+# ❌ Stacking PR numbers or changelog voice in the subject
+fix: surface errors to clients as $error (#1338)
+```
+
+When committing via the agent: use a HEREDOC message that matches this format; prefer `fix`/`feat`/`chore` with an optional scope when the change is clearly package-scoped.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,7 @@ jobs:
                   # this expects you to have a script called release, which does a build
                   # for your packages and calls changeset publish
                   publish-script: pnpm release
+                  commit-message: "chore: version packages"
+                  pr-title: "chore: version packages"
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -1013,11 +1013,13 @@ export class IORoom<
                 return;
             }
 
-            await Promise.all([
-                procedure.config.broadcast?.(inputs, eventContext),
-                procedure.config.self?.(inputs, eventContext),
-                procedure.config.sync?.(inputs, eventContext),
-            ]).then(async ([broadcast, self, sync]) => {
+            try {
+                const [broadcast, self, sync] = await Promise.all([
+                    procedure.config.broadcast?.(inputs, eventContext),
+                    procedure.config.self?.(inputs, eventContext),
+                    procedure.config.sync?.(inputs, eventContext),
+                ]);
+
                 const handleBroadcast = async () => {
                     if (!broadcast) return;
 
@@ -1060,7 +1062,13 @@ export class IORoom<
                 };
 
                 await Promise.all([handleBroadcast(), handleSelf(), handleSync()]);
-            });
+            } catch (error) {
+                pluvWs.handleError({
+                    error,
+                    room: this.id,
+                    session,
+                });
+            }
         };
     }
 

--- a/tests/unit/src/IORoom.procedureError.test.ts
+++ b/tests/unit/src/IORoom.procedureError.test.ts
@@ -1,0 +1,95 @@
+import { createIO } from "@pluv/io";
+import { describe, expect, it } from "vitest";
+import { TestPlatform, TestSocket } from "./__utils__";
+
+type Room = {
+    onMessage: (socket: TestSocket) => (event: { data: string }) => Promise<void>;
+    register: (socket: TestSocket) => Promise<void>;
+};
+
+const lastMessage = (socket: TestSocket, type: string): { type: string; data: any } => {
+    const message = [...socket.messages].reverse().find((entry) => entry.type === type);
+
+    if (!message) throw new Error(`Missing ${type} message`);
+
+    return message;
+};
+
+const send = async (room: Room, socket: TestSocket, type: string, data: unknown): Promise<void> => {
+    await room.onMessage(socket)({
+        data: JSON.stringify({ type, data }),
+    });
+};
+
+describe("IORoom procedure errors", () => {
+    it("sends $error when a procedure resolver throws", async () => {
+        const io = createIO({
+            platform: () => new TestPlatform({ mode: "detached" }),
+        });
+        const server = io.server({
+            router: io.router({
+                boom: io.procedure.broadcast(() => {
+                    throw new Error("procedure exploded");
+                }),
+            }),
+        });
+        const room = server.createRoom("procedure-throw");
+        const socket = new TestSocket("session-1");
+
+        await room.register(socket);
+        await send(room, socket, "boom", {});
+
+        expect(lastMessage(socket, "$error").data.message).toBe("procedure exploded");
+    });
+
+    it("sends $error when presence exceeds the size limit", async () => {
+        const io = createIO({
+            limits: { presenceMaxSize: 32 },
+            platform: () => new TestPlatform({ mode: "detached" }),
+        });
+        const server = io.server();
+        const room = server.createRoom("presence-limit");
+        const socket = new TestSocket("session-1");
+
+        await room.register(socket);
+        await send(room, socket, "$initializeSession", { presence: {}, update: null });
+        await send(room, socket, "$updatePresence", {
+            presence: { note: "x".repeat(64) },
+        });
+
+        expect(lastMessage(socket, "$error").data.message).toMatch(/Presence must be at most/);
+    });
+
+    it("still sends $error for invalid procedure input", async () => {
+        const io = createIO({
+            platform: () => new TestPlatform({ mode: "detached" }),
+        });
+        const server = io.server({
+            router: io.router({
+                echo: io.procedure
+                    .input({
+                        parse: (data: unknown) => {
+                            if (
+                                typeof data !== "object" ||
+                                data === null ||
+                                typeof (data as { message?: unknown }).message !== "string"
+                            ) {
+                                throw new Error("Expected { message: string }");
+                            }
+
+                            return data as { message: string };
+                        },
+                        _input: { message: "" },
+                    })
+                    .broadcast(({ message }) => ({ echoed: { message } })),
+            }),
+        });
+        const room = server.createRoom("invalid-input");
+        const socket = new TestSocket("session-1");
+
+        await room.register(socket);
+        await send(room, socket, "echo", { message: 1 });
+
+        expect(lastMessage(socket, "$error").data.message).toBe("Expected { message: string }");
+    });
+});


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/main/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Send `$error` when a procedure resolver or size-limit check throws, instead of leaving an unhandled rejection.