### PR TITLE
fix(io): keep broadcasts delivering when one socket send fails

### DIFF
--- a/.changeset/kind-wolves-share.md
+++ b/.changeset/kind-wolves-share.md
@@ -1,0 +1,7 @@
+---
+"@pluv/io": patch
+---
+
+Keep room broadcasts reliable when one socket fails to send.
+
+A single dead or erroring connection no longer risks dropping the rest of the fan-out or leaving an unhandled rejection while delivering events to everyone else.

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -1166,14 +1166,14 @@ export class IORoom<
                 return pluvWs ? dict.set(id, pluvWs) : dict;
             }, new Map<string, AbstractWebSocket<any, TAuthorize>>()) ?? this._sessions;
 
-        const promises = Array.from(webSockets.values()).map(async (pluvWs) => {
-            const session = pluvWs.session;
-            const user = session.user ?? null;
+        await Promise.allSettled(
+            Array.from(webSockets.values()).map(async (pluvWs) => {
+                const session = pluvWs.session;
+                const user = session.user ?? null;
 
-            this._sendMessage(pluvWs, { connectionId, data, room, type, user });
-        });
-
-        await Promise.all(promises);
+                await this._sendMessage(pluvWs, { connectionId, data, room, type, user });
+            }),
+        );
     }
 
     private async _sendSelfMessage(

--- a/tests/unit/src/IORoom.broadcastFanout.test.ts
+++ b/tests/unit/src/IORoom.broadcastFanout.test.ts
@@ -1,0 +1,53 @@
+import { createIO } from "@pluv/io";
+import { describe, expect, it } from "vitest";
+import { TestPlatform, TestSocket, tick } from "./__utils__";
+
+type Room = {
+    onMessage: (socket: TestSocket) => (event: { data: string }) => Promise<void>;
+    register: (socket: TestSocket) => Promise<void>;
+};
+
+const lastMessage = (socket: TestSocket, type: string): { type: string; data: any } => {
+    const message = [...socket.messages].reverse().find((entry) => entry.type === type);
+
+    if (!message) throw new Error(`Missing ${type} message`);
+
+    return message;
+};
+
+const send = async (room: Room, socket: TestSocket, type: string, data: unknown): Promise<void> => {
+    await room.onMessage(socket)({
+        data: JSON.stringify({ type, data }),
+    });
+};
+
+describe("IORoom broadcast fan-out", () => {
+    it("still delivers to healthy sockets when another send throws", async () => {
+        const io = createIO({
+            platform: () => new TestPlatform({ mode: "detached" }),
+        });
+        const server = io.server();
+        const room = server.createRoom("fanout");
+        const healthy = new TestSocket("session-healthy");
+        const broken = new TestSocket("session-broken");
+
+        await room.register(healthy);
+        await room.register(broken);
+        await send(room, healthy, "$initializeSession", { presence: {}, update: null });
+        await send(room, broken, "$initializeSession", { presence: {}, update: null });
+
+        broken.throwOnSend = new Error("socket send failed");
+
+        // Broken socket throws on every outbound message after this point.
+        await expect(
+            send(room, healthy, "$updatePresence", { presence: { cursor: 1 } }),
+        ).resolves.toBeUndefined();
+
+        // Pub/sub delivery is async relative to the originating handler in some paths;
+        // drain microtasks so the fan-out has settled.
+        await tick(2);
+
+        expect(lastMessage(healthy, "$presenceUpdated").data.presence).toEqual({ cursor: 1 });
+        expect(broken.sent.some((raw) => JSON.parse(raw).type === "$presenceUpdated")).toBe(false);
+    });
+});

--- a/tests/unit/src/__utils__/TestWebSocket.ts
+++ b/tests/unit/src/__utils__/TestWebSocket.ts
@@ -18,6 +18,8 @@ export class TestSocket {
     public readonly id: string;
     public readonly sent: string[] = [];
     public readyState: 0 | 1 | 2 | 3 = 1;
+    /** When set, `TestWebSocket.send` throws instead of recording the message. */
+    public throwOnSend: Error | null = null;
 
     private readonly _listeners = new Map<string, Set<TestSocketListener>>();
 
@@ -119,6 +121,8 @@ export class TestWebSocket<
 
     public send(message: string | ArrayBuffer | ArrayBufferView): void {
         if (this.readyState !== this.OPEN) return;
+
+        if (this.webSocket.throwOnSend) throw this.webSocket.throwOnSend;
 
         this.webSocket.sent.push(
             typeof message === "string"


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/main/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Keep room broadcasts reliable when one socket fails to send.

A single dead or erroring connection no longer risks dropping the rest of the fan-out or leaving an unhandled rejection while delivering events to everyone else.