### PR TITLE
feat: require io authorization

### DIFF
--- a/.changeset/require-io-authorization.md
+++ b/.changeset/require-io-authorization.md
@@ -1,0 +1,13 @@
+---
+"@pluv/io": major
+"@pluv/types": major
+"@pluv/client": major
+"@pluv/react": major
+"@pluv/platform-node": major
+"@pluv/platform-cloudflare": major
+"@pluv/platform-pluv": major
+---
+
+Require authorization for every room connection.
+
+Open (unauthorized) rooms are removed: `createIO` must configure `authorize`, clients must provide an `authEndpoint`, and connections without a valid token are rejected. Session users are always typed from your authorize schema (at least `{ id: string }`), not `null`.

--- a/apps/docs/content/docs/api-reference/io.mdx
+++ b/apps/docs/content/docs/api-reference/io.mdx
@@ -75,7 +75,12 @@ import { createIO } from "@pluv/io";
 import { platformNode } from "@pluv/platform-node";
 import { z } from "zod";
 
-const io = createIO(platformNode());
+const io = createIO(platformNode({
+  authorize: {
+    secret: process.env.PLUV_AUTH_SECRET!,
+    user: z.object({ id: z.string() }),
+  },
+}));
 
 const sendMessage = io.procedure
   .input(z.object({ message: z.string() }))
@@ -98,7 +103,12 @@ import { createIO } from "@pluv/io";
 import { platformNode } from "@pluv/platform-node";
 import { z } from "zod";
 
-const io = createIO(platformNode());
+const io = createIO(platformNode({
+  authorize: {
+    secret: process.env.PLUV_AUTH_SECRET!,
+    user: z.object({ id: z.string() }),
+  },
+}));
 
 const sendMessage = io.procedure
   .input(z.object({ message: z.string() }))
@@ -129,7 +139,12 @@ import { createIO } from "@pluv/io";
 import { platformNode } from "@pluv/platform-node";
 import { z } from "zod";
 
-const io = createIO(platformNode());
+const io = createIO(platformNode({
+  authorize: {
+    secret: process.env.PLUV_AUTH_SECRET!,
+    user: z.object({ id: z.string() }),
+  },
+}));
 const router = io.router({ /* ... */ });
 
 const server = io.server({

--- a/apps/docs/content/docs/guides/authorization.mdx
+++ b/apps/docs/content/docs/guides/authorization.mdx
@@ -3,7 +3,7 @@ title: "Authorization"
 description: "Learn how to add custom authorization to rooms in @pluv/io"
 ---
 
-> **Note**: Authorization is required when using `@pluv/platform-pluv`.
+> **Note**: Authorization is required for all platforms. Every `createIO` must configure `authorize`, and every client must provide an `authEndpoint`.
 
 pluv.io uses JWTs to authorize access to rooms on a new connection. To generate a JWT, you will need to setup an authentication endpoint to determine if the user should have access to the room.
 
@@ -17,7 +17,7 @@ You can view another example of these via your platform's respective quickstart 
 
 ## Enable authorization on io
 
-Set the `authorize` property on your `createIO` config to enable authorization on your io instance.
+Set the required `authorize` property on your `createIO` config. The `user` schema must always include `id`.
 
 ```ts
 // server/io.ts

--- a/apps/docs/content/docs/guides/events/server.mdx
+++ b/apps/docs/content/docs/guides/events/server.mdx
@@ -14,7 +14,12 @@ import { createIO } from "@pluv/io";
 import { platformNode } from "@pluv/platform-node";
 import { z } from "zod";
 
-const io = createIO(platformNode());
+const io = createIO(platformNode({
+  authorize: {
+    secret: process.env.PLUV_AUTH_SECRET!,
+    user: z.object({ id: z.string() }),
+  },
+}));
 
 // Create your custom events as procedures
 const sendMessage = io.procedure

--- a/docs/api-reference/io.mdx
+++ b/docs/api-reference/io.mdx
@@ -77,7 +77,12 @@ import { createIO } from "@pluv/io";
 import { platformNode } from "@pluv/platform-node";
 import { z } from "zod";
 
-const io = createIO(platformNode());
+const io = createIO(platformNode({
+  authorize: {
+    secret: process.env.PLUV_AUTH_SECRET!,
+    user: z.object({ id: z.string() }),
+  },
+}));
 
 const sendMessage = io.procedure
   .input(z.object({ message: z.string() }))
@@ -100,7 +105,12 @@ import { createIO } from "@pluv/io";
 import { platformNode } from "@pluv/platform-node";
 import { z } from "zod";
 
-const io = createIO(platformNode());
+const io = createIO(platformNode({
+  authorize: {
+    secret: process.env.PLUV_AUTH_SECRET!,
+    user: z.object({ id: z.string() }),
+  },
+}));
 
 const sendMessage = io.procedure
   .input(z.object({ message: z.string() }))
@@ -131,7 +141,12 @@ import { createIO } from "@pluv/io";
 import { platformNode } from "@pluv/platform-node";
 import { z } from "zod";
 
-const io = createIO(platformNode());
+const io = createIO(platformNode({
+  authorize: {
+    secret: process.env.PLUV_AUTH_SECRET!,
+    user: z.object({ id: z.string() }),
+  },
+}));
 const router = io.router({ /* ... */ });
 
 const server = io.server({

--- a/docs/authorization.mdx
+++ b/docs/authorization.mdx
@@ -5,7 +5,7 @@ description: "Learn how to add custom authorization to rooms in @pluv/io"
 
 # Authorization
 
-> **Note**: Authorization is required when using `@pluv/platform-pluv`.
+> **Note**: Authorization is required for all platforms. Every `createIO` must configure `authorize`, and every client must provide an `authEndpoint`.
 
 pluv.io uses JWTs to authorize access to rooms on a new connection. To generate a JWT, you will need to setup an authentication endpoint to determine if the user should have access to the room.
 
@@ -19,7 +19,7 @@ You can view another example of these via your platform's respective quickstart 
 
 ## Enable authorization on io
 
-Set the `authorize` property on your `createIO` config to enable authorization on your io instance.
+Set the required `authorize` property on your `createIO` config. The `user` schema must always include `id`.
 
 ```ts
 // server/io.ts

--- a/docs/custom-events/server-events.mdx
+++ b/docs/custom-events/server-events.mdx
@@ -16,7 +16,12 @@ import { createIO } from "@pluv/io";
 import { platformNode } from "@pluv/platform-node";
 import { z } from "zod";
 
-const io = createIO(platformNode());
+const io = createIO(platformNode({
+  authorize: {
+    secret: process.env.PLUV_AUTH_SECRET!,
+    user: z.object({ id: z.string() }),
+  },
+}));
 
 // Create your custom events as procedures
 const sendMessage = io.procedure

--- a/packages/client/src/PluvClient.ts
+++ b/packages/client/src/PluvClient.ts
@@ -65,7 +65,7 @@ export class PluvClient<
 > {
     public readonly metadata?: InputZodLike<TMetadata>;
 
-    private readonly _authEndpoint: AuthEndpoint<TMetadata> | undefined;
+    private readonly _authEndpoint: AuthEndpoint<TMetadata>;
     private readonly _debug: boolean;
     private readonly _initialStorage?: TCrdt;
     private readonly _limits: PluvClientLimits;
@@ -98,7 +98,7 @@ export class PluvClient<
 
         this.metadata = metadata;
 
-        this._authEndpoint = authEndpoint as AuthEndpoint<TMetadata>;
+        this._authEndpoint = authEndpoint;
         this._debug = debug;
         this._initialStorage = initialStorage as TCrdt;
         this._limits = {

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -8,7 +8,6 @@ import type {
 } from "@pluv/crdt";
 import type {
     BaseIOEventRecord,
-    BaseUser,
     BroadcastProxy,
     CrdtDocLike,
     EventMessage,
@@ -135,9 +134,8 @@ type FetchOptions = { url: string; options?: RequestInit };
 
 export type RoomEndpoints<TIO extends IOLike<any, any, any>, TMetadata extends JsonObject> = {
     wsEndpoint?: WsEndpoint<TMetadata>;
-} & (InferIOAuthorizeUser<InferIOAuthorize<TIO>> extends BaseUser
-    ? { authEndpoint: AuthEndpoint<TMetadata> }
-    : { authEndpoint?: undefined });
+    authEndpoint: AuthEndpoint<TMetadata>;
+};
 
 interface InternalListeners {
     onAuthorizationFail: (error: Error) => void;
@@ -1017,7 +1015,7 @@ export class PluvRoom<
 
         this._updateState((oldState) => {
             oldState.connection.id = connectionId;
-            oldState.authorization.user = user ?? null;
+            oldState.authorization.user = user;
 
             return oldState;
         });

--- a/packages/client/src/UsersManager.ts
+++ b/packages/client/src/UsersManager.ts
@@ -152,20 +152,15 @@ export class UsersManager<TIO extends IOLike, TPresence extends Record<string, a
     }
 
     /**
-     * @description The client id is either the user's id (if authorized) or the connection id
-     * otherwise. This is so that, despite having multiple connections, the user will only have one
-     * presence to all other users.
+     * @description The client id is the authorized user's id. This is so that, despite having
+     * multiple connections, the user will only have one presence to all other users.
      * @date April 16, 2025
      */
     public getClientId(connectionId: string): string | null;
     public getClientId(userInfo: UserInfo<TIO, TPresence>): string;
     public getClientId(input: string | UserInfo<TIO, TPresence>): string | null {
         if (typeof input !== "string") {
-            const userInfo = input;
-            const connectionId = userInfo.connectionId;
-            const userId = userInfo.user?.id ?? null;
-
-            return userId ?? connectionId;
+            return input.user.id;
         }
 
         const connectionId = input;

--- a/packages/io/src/AbstractPlatform.ts
+++ b/packages/io/src/AbstractPlatform.ts
@@ -1,4 +1,3 @@
-import type { Maybe } from "@pluv/types";
 import type { AbstractPersistence } from "./AbstractPersistence";
 import type { AbstractPubSub } from "./AbstractPubSub";
 import type { AbstractWebSocket, InferWebSocketSource } from "./AbstractWebSocket";
@@ -48,7 +47,7 @@ export abstract class AbstractPlatform<
     public abstract readonly id: string;
     public readonly _createToken?: (
         params: JWTEncodeParams<any, any> & {
-            authorize: Maybe<ResolvedPluvIOAuthorize<any, any>>;
+            authorize: ResolvedPluvIOAuthorize<any, any>;
         },
     ) => Promise<string>;
     public _fetch?: (...args: any[]) => Promise<any>;

--- a/packages/io/src/AbstractWebSocket.ts
+++ b/packages/io/src/AbstractWebSocket.ts
@@ -1,5 +1,4 @@
 import type {
-    BaseUser,
     InferIOAuthorizeUser,
     IOAuthorize,
     IOEventMessage,
@@ -56,7 +55,7 @@ export interface AbstractWebSocketConfig {
 
 export abstract class AbstractWebSocket<
     TWebSocket = any,
-    TAuthorize extends IOAuthorize<any, any> | null = null,
+    TAuthorize extends IOAuthorize<any, any> = IOAuthorize<any, any>,
 > {
     /** The connection is not yet open. */
     public readonly CONNECTING = 0;
@@ -79,6 +78,11 @@ export abstract class AbstractWebSocket<
     public abstract get sessionId(): string;
     public abstract get state(): WebSocketSerializedState;
     public abstract set state(state: WebSocketSerializedState);
+    /**
+     * @description Authorized user for this socket. `null` until `register` (or hibernation
+     * reattach) has assigned one.
+     */
+    public abstract get user(): InferIOAuthorizeUser<TAuthorize> | null;
     public abstract set user(user: InferIOAuthorizeUser<TAuthorize>);
 
     constructor(webSocket: TWebSocket, config: AbstractWebSocketConfig) {

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -2,7 +2,6 @@ import type { AbstractCrdtDocFactory } from "@pluv/crdt";
 import { noop } from "@pluv/crdt";
 import type {
     BaseIOEventRecord,
-    BaseUser,
     CrdtDocLike,
     CrdtLibraryType,
     EventMessage,
@@ -61,7 +60,7 @@ interface BroadcastParams<TIO extends IORoom<any, any, any, any, any>> {
 
 export interface IORoomListeners<
     TPlatform extends AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>>,
     TContext extends Record<string, any>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>,
 > {
@@ -83,12 +82,12 @@ export type BroadcastProxy<TIO extends IORoom<any, any, any, any, any>> = (<
 
 export type IORoomConfig<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null =
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
         any,
     TContext extends Record<string, any> = {},
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
 > = Partial<IORoomListeners<TPlatform, TAuthorize, TContext, TEvents>> & {
-    authorize?: TAuthorize;
+    authorize: TAuthorize;
     context: PluvContext<TPlatform, TContext>;
     crdt?: { doc: (value: any) => AbstractCrdtDocFactory<any, any> };
     debug: boolean;
@@ -117,8 +116,8 @@ export type WebSocketRegisterConfig<
 
 export class IORoom<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null =
-        null,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
+        any,
     TContext extends Record<string, any> = {},
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
@@ -130,7 +129,7 @@ export class IORoom<
     private _teardown: Promise<void> | null = null;
     private _uninitialize: Promise<() => Promise<void>> | null = null;
 
-    private readonly _authorize: TAuthorize = null as TAuthorize;
+    private readonly _authorize: TAuthorize;
     private readonly _context: PluvContext<TPlatform, TContext>;
     private readonly _crdt: TCrdt;
     private readonly _debug: boolean;
@@ -218,6 +217,7 @@ export class IORoom<
         this._roomContext = roomContext;
         this._router = router;
         this._platform = platform.initialize({ ...(!!_meta ? { _meta } : {}), roomContext });
+        this._authorize = authorizeConfig;
 
         // Listeners are provided from server-level configuration via createRoom
         this._listeners = {
@@ -227,8 +227,6 @@ export class IORoom<
             onUserConnected: (event) => onUserConnected?.(event),
             onUserDisconnected: (event) => onUserDisconnected?.(event),
         };
-
-        if (authorizeConfig) this._authorize = authorizeConfig;
 
         /**
          * @description Everything below this line relates to waking up from hibernation.
@@ -249,7 +247,7 @@ export class IORoom<
 
             this._sessions.set(sessionId, pluvWs);
 
-            const userId = pluvWs.session.user?.id;
+            const userId = pluvWs.user?.id;
 
             if (!!userId) this._addUserSession(userId, sessionId);
         });
@@ -378,12 +376,10 @@ export class IORoom<
             await this._initialized;
         }
 
-        const user: BaseUser | null = await this._getAuthorizedUser(token, _options);
-        const ioAuthorize = this._getIOAuthorize(_options);
-        const isUnauthorized = !!ioAuthorize && !user;
+        const user = await this._getAuthorizedUser(token, _options);
         const pluvWs = this._platform.convertWebSocket(webSocket, { room: this.id });
 
-        if (isUnauthorized) {
+        if (!user) {
             this._logDebug(colors.blue("Authorization failed for connection"));
             pluvWs.handleError({ error: new Error("Not authorized"), room: this.id });
             pluvWs.close(3000, "WebSocket unauthorized.");
@@ -391,19 +387,17 @@ export class IORoom<
             return;
         }
 
-        if (!!user) {
-            const latest = this._getLatestPresence(user.id);
-            const prevState = pluvWs.state;
+        const latest = this._getLatestPresence(user.id);
+        const prevState = pluvWs.state;
 
-            pluvWs.user = user;
+        pluvWs.user = user;
 
-            this._platform.setSerializedState(pluvWs, {
-                ...prevState,
-                presence: latest.presence,
-                timers: { ...prevState.timers, presence: latest.timer },
-            });
-            this._addUserSession(user.id, pluvWs.sessionId);
-        }
+        this._platform.setSerializedState(pluvWs, {
+            ...prevState,
+            presence: latest.presence,
+            timers: { ...prevState.timers, presence: latest.timer },
+        });
+        this._addUserSession(user.id, pluvWs.sessionId);
 
         this._logDebug(
             `${colors.blue(`Registering connection for room ${this.id}:`)} ${pluvWs.sessionId}`,
@@ -411,7 +405,7 @@ export class IORoom<
 
         await this._platform.acceptWebSocket(pluvWs);
         this._sessions.set(pluvWs.sessionId, pluvWs);
-        await this._platform.persistence.addUser(this.id, pluvWs.sessionId, user ?? {});
+        await this._platform.persistence.addUser(this.id, pluvWs.sessionId, user);
 
         if (this._platform._config.registrationMode === "attached") {
             const onClose = this._onClose(pluvWs).bind(this);
@@ -618,11 +612,10 @@ export class IORoom<
     private async _getAuthorizedUser(
         token: Maybe<string>,
         options: WebSocketRegisterConfig<TPlatform>,
-    ): Promise<InferIOAuthorizeUser<TAuthorize>> {
+    ): Promise<InferIOAuthorizeUser<TAuthorize> | null> {
         const ioAuthorize = this._getIOAuthorize(options);
 
-        if (!ioAuthorize) return null as any;
-        if (!token) return null as any;
+        if (!token) return null;
 
         if (!ioAuthorize.secret)
             throw new Error("`authorize` was specified without a valid secret");
@@ -636,7 +629,7 @@ export class IORoom<
             this._logDebug(colors.blue("Could not decode token:"));
             this._logDebug(token);
 
-            return null as any;
+            return null;
         }
 
         if (payload.room !== this.id) {
@@ -644,15 +637,15 @@ export class IORoom<
             this._logDebug(colors.blue("Received:"), payload.room);
             this._logDebug(token);
 
-            return null as any;
+            return null;
         }
 
         try {
-            return ioAuthorize.user.parse(payload.user) ?? null;
+            return ioAuthorize.user.parse(payload.user);
         } catch {
             this._logDebug(`${colors.blue("Token fails validation:")} ${token}`);
 
-            return null as any;
+            return null;
         }
     }
 
@@ -700,18 +693,16 @@ export class IORoom<
 
     private _getIOAuthorize(
         options: WebSocketRegisterConfig<TPlatform>,
-    ): ResolvedPluvIOAuthorize<any, any> | null {
+    ): ResolvedPluvIOAuthorize<any, any> {
         if (typeof this._authorize === "function") return this._authorize(options);
 
-        return this._authorize as ResolvedPluvIOAuthorize<any, any> | null;
+        return this._authorize as ResolvedPluvIOAuthorize<any, any>;
     }
 
     private _getLatestPresence(userId: string): {
         timer: number | null;
         presence: JsonObject | null;
     } {
-        if (!this._authorize) return { timer: null, presence: null };
-
         const sessionIds = Array.from(this._userSessionss.get(userId)?.values() ?? []);
 
         if (!sessionIds.length) return { timer: null, presence: null };
@@ -726,7 +717,7 @@ export class IORoom<
                 const presence = session.presence;
                 const timer = session.timers.presence;
 
-                if (session.user?.id !== userId) return state;
+                if (session.user.id !== userId) return state;
                 if (typeof state.timer !== "number") return { presence, timer };
                 if (typeof timer !== "number") return state;
 
@@ -1097,7 +1088,7 @@ export class IORoom<
         if (!pluvWs) return;
 
         const wsSession = pluvWs.session;
-        const user = wsSession.user as BaseUser | null;
+        const user = wsSession.user;
 
         const sessionIds = user
             ? new Set<string>([...(this._userSessionss.get(user.id) ?? []), sessionId])
@@ -1169,7 +1160,7 @@ export class IORoom<
         await Promise.allSettled(
             Array.from(webSockets.values()).map(async (pluvWs) => {
                 const session = pluvWs.session;
-                const user = session.user ?? null;
+                const user = session.user;
 
                 await this._sendMessage(pluvWs, { connectionId, data, room, type, user });
             }),
@@ -1189,7 +1180,7 @@ export class IORoom<
         if (!pluvWs) return;
 
         const session = pluvWs.session;
-        const user = session.user ?? null;
+        const user = session.user;
 
         await this._sendMessage(pluvWs, {
             connectionId: senderId,
@@ -1281,7 +1272,7 @@ export class IORoom<
                     options: { type: "self" },
                     room: this.id,
                     type,
-                    user: (sender.user ?? null) as BaseUser | null,
+                    user: sender.user,
                 });
             }),
         );

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -82,8 +82,7 @@ export type BroadcastProxy<TIO extends IORoom<any, any, any, any, any>> = (<
 
 export type IORoomConfig<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
-        any,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> = any,
     TContext extends Record<string, any> = {},
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
 > = Partial<IORoomListeners<TPlatform, TAuthorize, TContext, TEvents>> & {
@@ -116,8 +115,7 @@ export type WebSocketRegisterConfig<
 
 export class IORoom<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
-        any,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> = any,
     TContext extends Record<string, any> = {},
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},

--- a/packages/io/src/PluvIO.ts
+++ b/packages/io/src/PluvIO.ts
@@ -29,11 +29,11 @@ import { __PLUV_VERSION } from "./version";
 
 export type PluvIOConfig<
     TPlatform extends AbstractPlatform<any>,
-    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>> | null,
+    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>>,
     TContext extends Record<string, any>,
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
 > = {
-    authorize?: TAuthorize;
+    authorize: TAuthorize;
     context?: PluvContext<TPlatform, TContext>;
     crdt?: TCrdt;
     debug?: boolean;
@@ -43,7 +43,7 @@ export type PluvIOConfig<
 
 type ResolvedServerConfig<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null =
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
         any,
     TContext extends Record<string, any> = {},
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
@@ -56,7 +56,7 @@ type ResolvedServerConfig<
 
 export type BaseServerConfig<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null =
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
         any,
     TContext extends Record<string, any> = {},
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
@@ -83,7 +83,7 @@ export type BaseServerConfig<
 
 export type ServerConfig<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null =
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
         any,
     TContext extends Record<string, any> = {},
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
@@ -97,14 +97,14 @@ export type ServerConfig<
 
 export class PluvIO<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null =
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
         any,
     TContext extends Record<string, any> = {},
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
 > {
     public readonly version: string = __PLUV_VERSION as any;
 
-    private readonly _authorize: TAuthorize = null as TAuthorize;
+    private readonly _authorize: TAuthorize;
     private readonly _context: PluvContext<TPlatform, TContext> = {} as PluvContext<
         TPlatform,
         TContext
@@ -128,6 +128,7 @@ export class PluvIO<
             platform,
         } = options;
 
+        this._authorize = authorizeConfig;
         this._crdt = crdt as CrdtLibraryType<any>;
         this._debug = debug;
         this._limits = {
@@ -139,20 +140,15 @@ export class PluvIO<
         };
         this._platform = platform;
 
-        if (authorizeConfig) this._authorize = authorizeConfig;
         if (context) this._context = context;
     }
 
     public async createToken(
         params: JWTEncodeParams<InferIOAuthorizeUser<TAuthorize>, TPlatform>,
     ): Promise<string> {
-        if (!this._authorize) {
-            throw new Error("IO does not specify authorize during initialization.");
-        }
-
         const ioAuthorize = this._getIOAuthorize(params);
         const user = params.user as BaseUser;
-        const parsed = !!ioAuthorize ? ioAuthorize.user.parse(user) : user;
+        const parsed = ioAuthorize.user.parse(user);
 
         if (!!this._limits.userIdMaxLength && user.id.length > this._limits.userIdMaxLength) {
             throw new Error(oneLine`
@@ -182,7 +178,7 @@ export class PluvIO<
             return await platform._createToken({ ...params, authorize: ioAuthorize });
         }
 
-        const secret = ioAuthorize?.secret ?? null;
+        const secret = ioAuthorize.secret ?? null;
 
         if (!secret) throw new Error("`authorize` was specified without a valid secret");
 
@@ -224,7 +220,7 @@ export class PluvIO<
 
         return new PluvServer<TPlatform, TAuthorize, TContext, TCrdt, TEvents>({
             ...serverConfig,
-            authorize: this._authorize ?? undefined,
+            authorize: this._authorize,
             context: this._context,
             crdt: this._crdt,
             debug: this._debug,
@@ -236,11 +232,11 @@ export class PluvIO<
 
     private _getIOAuthorize(
         options: WebSocketRegisterConfig<TPlatform>,
-    ): ResolvedPluvIOAuthorize<any, any> | null {
+    ): ResolvedPluvIOAuthorize<any, any> {
         if (typeof this._authorize === "function") {
             return this._authorize(options);
         }
 
-        return this._authorize as ResolvedPluvIOAuthorize<any, any> | null;
+        return this._authorize as ResolvedPluvIOAuthorize<any, any>;
     }
 }

--- a/packages/io/src/PluvIO.ts
+++ b/packages/io/src/PluvIO.ts
@@ -43,8 +43,7 @@ export type PluvIOConfig<
 
 type ResolvedServerConfig<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
-        any,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> = any,
     TContext extends Record<string, any> = {},
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
@@ -56,8 +55,7 @@ type ResolvedServerConfig<
 
 export type BaseServerConfig<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
-        any,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> = any,
     TContext extends Record<string, any> = {},
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
@@ -83,8 +81,7 @@ export type BaseServerConfig<
 
 export type ServerConfig<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
-        any,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> = any,
     TContext extends Record<string, any> = {},
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
@@ -97,8 +94,7 @@ export type ServerConfig<
 
 export class PluvIO<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
-        any,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> = any,
     TContext extends Record<string, any> = {},
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
 > {

--- a/packages/io/src/PluvProcedure.ts
+++ b/packages/io/src/PluvProcedure.ts
@@ -10,7 +10,7 @@ import type { EventResolver, EventResolverKind, MergeEventRecords } from "./type
 
 export interface PluvProcedureConfig<
     TPlatform extends AbstractPlatform<any>,
-    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>> | null,
+    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>>,
     TContext extends Record<string, any>,
     TInput extends JsonObject = {},
     TOutput extends EventRecord<string, any> = {},
@@ -30,7 +30,7 @@ export interface PluvProcedureConfig<
 
 export class PluvProcedure<
     TPlatform extends AbstractPlatform<any>,
-    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>> | null,
+    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>>,
     TContext extends Record<string, any>,
     TInput extends JsonObject = {},
     TOutput extends EventRecord<string, any> = {},

--- a/packages/io/src/PluvRouter.ts
+++ b/packages/io/src/PluvRouter.ts
@@ -5,7 +5,7 @@ import type { PluvIOAuthorize } from "./types";
 
 export type PluvRouterEventConfig<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null =
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
         any,
     TContext extends Record<string, any> = {},
 > = { [P: string]: Pick<PluvProcedure<TPlatform, TAuthorize, TContext, any, any>, "config"> };
@@ -25,7 +25,7 @@ export type MergedRouter<
 
 export class PluvRouter<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null =
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
         any,
     TContext extends Record<string, any> = {},
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},

--- a/packages/io/src/PluvRouter.ts
+++ b/packages/io/src/PluvRouter.ts
@@ -5,8 +5,7 @@ import type { PluvIOAuthorize } from "./types";
 
 export type PluvRouterEventConfig<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
-        any,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> = any,
     TContext extends Record<string, any> = {},
 > = { [P: string]: Pick<PluvProcedure<TPlatform, TAuthorize, TContext, any, any>, "config"> };
 
@@ -25,8 +24,7 @@ export type MergedRouter<
 
 export class PluvRouter<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
-        any,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> = any,
     TContext extends Record<string, any> = {},
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
 > implements IORouterLike<TEvents> {

--- a/packages/io/src/PluvServer.ts
+++ b/packages/io/src/PluvServer.ts
@@ -47,13 +47,13 @@ export type InferIORoom<TServer extends PluvServer<any, any, any, any, any>> =
 
 export type PluvServerConfig<
     TPlatform extends AbstractPlatform<any, any> = AbstractPlatform<any, any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null =
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
         any,
     TContext extends Record<string, any> = {},
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
 > = Partial<PluvIOListeners<TPlatform, TAuthorize, TContext, TEvents>> & {
-    authorize?: TAuthorize;
+    authorize: TAuthorize;
     context?: PluvContext<TPlatform, TContext>;
     crdt?: { doc: (value: any) => AbstractCrdtDocFactory<any, any> };
     debug?: boolean;
@@ -67,7 +67,7 @@ export type PluvServerConfig<
 
 type BaseCreateRoomOptions<
     TPlatform extends AbstractPlatform<any, any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>>,
     TContext extends Record<string, any>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>,
 > = {
@@ -76,7 +76,7 @@ type BaseCreateRoomOptions<
 
 export type CreateRoomOptions<
     TPlatform extends AbstractPlatform<any, any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>>,
     TContext extends Record<string, any>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>,
 > = keyof Omit<InferRoomContextType<TPlatform>, "meta"> extends never
@@ -90,7 +90,7 @@ export type CreateRoomOptions<
 
 export class PluvServer<
     TPlatform extends AbstractPlatform<any, any> = AbstractPlatform<any, any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null =
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
         any,
     TContext extends Record<string, any> = {},
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
@@ -417,7 +417,7 @@ export class PluvServer<
 
         const newRoom = new IORoom<TPlatform, TAuthorize, TContext, TCrdt, TEvents>(room, {
             ...(!!_meta ? { _meta } : {}),
-            authorize: this._config.authorize ?? undefined,
+            authorize: this._config.authorize,
             context: this._config.context,
             crdt: this._config.crdt,
             debug: debug ?? this._config.debug,

--- a/packages/io/src/PluvServer.ts
+++ b/packages/io/src/PluvServer.ts
@@ -47,8 +47,7 @@ export type InferIORoom<TServer extends PluvServer<any, any, any, any, any>> =
 
 export type PluvServerConfig<
     TPlatform extends AbstractPlatform<any, any> = AbstractPlatform<any, any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
-        any,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> = any,
     TContext extends Record<string, any> = {},
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},
@@ -90,8 +89,7 @@ export type CreateRoomOptions<
 
 export class PluvServer<
     TPlatform extends AbstractPlatform<any, any> = AbstractPlatform<any, any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> =
-        any,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> = any,
     TContext extends Record<string, any> = {},
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext> = {},

--- a/packages/io/src/authorize.ts
+++ b/packages/io/src/authorize.ts
@@ -16,12 +16,12 @@ export interface JWT<TUser extends BaseUser> {
 }
 
 export type JWTEncodeParams<
-    TUser extends BaseUser | null,
+    TUser extends BaseUser,
     TPlatform extends AbstractPlatform<any, any>,
 > = {
     maxAge?: number;
     room: string;
-    user: TUser extends BaseUser ? TUser : "Error: Cannot create token without authorization!";
+    user: TUser;
 } & InferInitContextType<TPlatform>;
 
 export interface AuthorizeParams {

--- a/packages/io/src/createIO.ts
+++ b/packages/io/src/createIO.ts
@@ -8,10 +8,10 @@ import type { PluvContext, PluvIOAuthorize, PluvIOLimits } from "./types";
 export type CreateIOParams<
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
     TContext extends Record<string, any> = {},
-    TUser extends BaseUser | null = null,
+    TUser extends BaseUser = BaseUser,
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
 > = {
-    authorize?: PluvIOAuthorize<TPlatform, TUser, InferInitContextType<TPlatform>>;
+    authorize: PluvIOAuthorize<TPlatform, TUser, InferInitContextType<TPlatform>>;
     context?: PluvContext<TPlatform, TContext>;
     crdt?: TCrdt;
     debug?: boolean;
@@ -22,7 +22,7 @@ export type CreateIOParams<
 export const createIO = <
     TPlatform extends AbstractPlatform<any> = AbstractPlatform<any>,
     TContext extends Record<string, any> = {},
-    TUser extends BaseUser | null = null,
+    TUser extends BaseUser = BaseUser,
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
 >(
     params: CreateIOParams<TPlatform, TContext, TUser, TCrdt>,

--- a/packages/io/src/types.ts
+++ b/packages/io/src/types.ts
@@ -33,7 +33,10 @@ export type EventResolverKind = "broadcast" | "self" | "sync";
 export type EventResolver<
     TKind extends EventResolverKind = EventResolverKind,
     TPlatform extends AbstractPlatform = AbstractPlatform,
-    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>> | null = null,
+    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>> = IOAuthorize<
+        any,
+        InferInitContextType<TPlatform>
+    >,
     TContext extends Record<string, any> = {},
     TInput extends JsonObject = {},
     TOutput extends EventRecord<string, any> = {},
@@ -45,7 +48,10 @@ export type EventResolver<
 export interface EventResolverContext<
     TKind extends EventResolverKind = EventResolverKind,
     TPlatform extends AbstractPlatform = AbstractPlatform,
-    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>> | null = null,
+    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>> = IOAuthorize<
+        any,
+        InferInitContextType<TPlatform>
+    >,
     TContext extends Record<string, any> = {},
 > {
     context: TContext;
@@ -79,7 +85,7 @@ export interface WebSocketSerializedState {
     timers: WebSocketSessionTimers;
 }
 
-export type WebSocketSession<TAuthorize extends IOAuthorize<any, any> | null = null> =
+export type WebSocketSession<TAuthorize extends IOAuthorize<any, any> = IOAuthorize<any, any>> =
     WebSocketSerializedState & {
         id: string;
         user: InferIOAuthorizeUser<TAuthorize>;
@@ -117,7 +123,6 @@ export interface PlatformConfig {
     authorize: {
         secret?: boolean;
     };
-    requireAuth?: boolean;
     handleMode: HandleMode;
     registrationMode: WebSocketRegistrationMode;
     listeners: {
@@ -141,13 +146,11 @@ export type ResolvedPluvIOAuthorize<
 
 export type PluvIOAuthorize<
     TPlatform extends AbstractPlatform<any, any, any, any>,
-    TUser extends BaseUser | null = any,
+    TUser extends BaseUser = any,
     TContext extends Record<string, unknown> = {},
 > =
-    | (TUser extends BaseUser ? ResolvedPluvIOAuthorize<TPlatform, TUser> : null)
-    | ((
-          context: TContext,
-      ) => TUser extends BaseUser ? ResolvedPluvIOAuthorize<TPlatform, TUser> : null);
+    | ResolvedPluvIOAuthorize<TPlatform, TUser>
+    | ((context: TContext) => ResolvedPluvIOAuthorize<TPlatform, TUser>);
 
 export interface PluvIOLimits {
     /**
@@ -170,7 +173,7 @@ export interface PluvIOLimits {
 
 export type BasePluvIOListeners<
     TPlatform extends AbstractPlatform<any, any, any, any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>>,
     TContext extends Record<string, any>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>,
 > = {
@@ -184,7 +187,7 @@ export type BasePluvIOListeners<
 
 export type PluvIOListeners<
     TPlatform extends AbstractPlatform<any, any, any, any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>>,
     TContext extends Record<string, any>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>,
 > = UndefinedProps<
@@ -197,7 +200,7 @@ export type PluvIOListeners<
 
 export type PluvIORouter<
     TPlatform extends AbstractPlatform<any, any, any, any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>>,
     TContext extends Record<string, any>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>,
 > =
@@ -254,7 +257,7 @@ export type IORoomDestroyedEvent<
 
 export type IORoomMessageEvent<
     TPlatform extends AbstractPlatform<any>,
-    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>> | null,
+    TAuthorize extends PluvIOAuthorize<TPlatform, any, InferInitContextType<TPlatform>>,
     TContext extends Record<string, any>,
     TEvents extends PluvRouterEventConfig<TPlatform, TAuthorize, TContext>,
 > = IORoomListenerEvent<TPlatform, TContext> & {
@@ -265,7 +268,7 @@ export type IORoomMessageEvent<
 
 export type IOStorageUpdatedEvent<
     TPlatform extends AbstractPlatform<any>,
-    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>> | null,
+    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>>,
     TContext extends Record<string, any>,
 > = IORoomListenerEvent<TPlatform, TContext> & {
     user?: InferIOAuthorizeUser<TAuthorize>;
@@ -274,7 +277,7 @@ export type IOStorageUpdatedEvent<
 
 export type IOUserConnectedEvent<
     TPlatform extends AbstractPlatform<any>,
-    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>> | null,
+    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>>,
     TContext extends Record<string, any>,
 > = IORoomListenerEvent<TPlatform, TContext> & {
     user?: InferIOAuthorizeUser<TAuthorize>;
@@ -283,7 +286,7 @@ export type IOUserConnectedEvent<
 
 export type IOUserDisconnectedEvent<
     TPlatform extends AbstractPlatform<any>,
-    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>> | null,
+    TAuthorize extends IOAuthorize<any, InferInitContextType<TPlatform>>,
     TContext extends Record<string, any>,
 > = IORoomListenerEvent<TPlatform, TContext> & {
     user?: InferIOAuthorizeUser<TAuthorize>;

--- a/packages/platform-cloudflare/src/CloudflarePlatform.ts
+++ b/packages/platform-cloudflare/src/CloudflarePlatform.ts
@@ -26,7 +26,7 @@ export type CloudflarePlatformConfig<
 };
 
 export class CloudflarePlatform<
-    TAuthorize extends IOAuthorize<any, any> | null = null,
+    TAuthorize extends IOAuthorize<any, any> = IOAuthorize<any, any>,
     TEnv extends Record<string, any> = {},
     TMeta extends Record<string, Json> = {},
 > extends AbstractPlatform<
@@ -38,7 +38,6 @@ export class CloudflarePlatform<
             secret: true;
         };
         handleMode: "io";
-        requireAuth: false;
         registrationMode: WebSocketRegistrationMode;
         listeners: {
             onRoomDestroyed: true;
@@ -77,7 +76,6 @@ export class CloudflarePlatform<
             },
             handleMode: "io" as const,
             registrationMode: config.mode ?? DEFAULT_REGISTRATION_MODE,
-            requireAuth: false as const,
             listeners: {
                 onRoomDestroyed: true as const,
                 onRoomMessage: true as const,

--- a/packages/platform-cloudflare/src/CloudflareWebSocket.ts
+++ b/packages/platform-cloudflare/src/CloudflareWebSocket.ts
@@ -18,7 +18,7 @@ export interface CloudflareWebSocketEventMap {
 export type CloudflareWebSocketConfig = AbstractWebSocketConfig;
 
 export class CloudflareWebSocket<
-    TAuthorize extends IOAuthorize<any, any> | null = null,
+    TAuthorize extends IOAuthorize<any, any> = IOAuthorize<any, any>,
 > extends AbstractWebSocket<WebSocket, TAuthorize> {
     public set presence(presence: JsonObject | null) {
         const deserialized = this.webSocket.deserializeAttachment();
@@ -38,7 +38,11 @@ export class CloudflareWebSocket<
         const deserialized = this.webSocket.deserializeAttachment();
         const sessionId = deserialized.sessionId as string;
         const state = this.state;
-        const user = (deserialized.user ?? null) as InferIOAuthorizeUser<TAuthorize>;
+        const user = this.user;
+
+        if (!user) {
+            throw new Error("WebSocket is not authorized");
+        }
 
         return {
             ...state,
@@ -83,6 +87,13 @@ export class CloudflareWebSocket<
         const deserialized = this.webSocket.deserializeAttachment();
 
         this.webSocket.serializeAttachment({ ...deserialized, state });
+    }
+
+    public get user(): InferIOAuthorizeUser<TAuthorize> | null {
+        const deserialized = this.webSocket.deserializeAttachment();
+        const user = deserialized?.user as InferIOAuthorizeUser<TAuthorize> | null | undefined;
+
+        return user ?? null;
     }
 
     public set user(user: InferIOAuthorizeUser<TAuthorize>) {

--- a/packages/platform-cloudflare/src/platformCloudflare.ts
+++ b/packages/platform-cloudflare/src/platformCloudflare.ts
@@ -9,7 +9,7 @@ export type PlatformCloudflareCreateIOParams<
     TEnv extends Record<string, any> = {},
     TMeta extends Record<string, Json> = {},
     TContext extends Record<string, any> = {},
-    TUser extends BaseUser | null = null,
+    TUser extends BaseUser = BaseUser,
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
 > = Id<
     CloudflarePlatformConfig<TEnv, TMeta> &
@@ -22,7 +22,7 @@ export type PlatformCloudflareCreateIOParams<
             >,
             "authorize" | "context" | "platform"
         > & {
-            authorize?: PluvIOAuthorize<
+            authorize: PluvIOAuthorize<
                 CloudflarePlatform<IOAuthorize<TUser, TContext>, TEnv, TMeta>,
                 TUser,
                 InferInitContextType<CloudflarePlatform<IOAuthorize<TUser, TContext>, TEnv, TMeta>>
@@ -39,10 +39,10 @@ export const platformCloudflare = <
     TEnv extends Record<string, any> = {},
     TMeta extends Record<string, Json> = {},
     TContext extends Record<string, any> = {},
-    TUser extends BaseUser | null = null,
+    TUser extends BaseUser = BaseUser,
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
 >(
-    config: PlatformCloudflareCreateIOParams<TEnv, TMeta, TContext, TUser, TCrdt> = {},
+    config: PlatformCloudflareCreateIOParams<TEnv, TMeta, TContext, TUser, TCrdt>,
 ): CreateIOParams<
     CloudflarePlatform<IOAuthorize<TUser, TContext>, TEnv, TMeta>,
     TContext,

--- a/packages/platform-node/src/NodePlatform.ts
+++ b/packages/platform-node/src/NodePlatform.ts
@@ -27,7 +27,7 @@ export type NodePlatformConfig<TMeta extends Record<string, Json>> = {
 ) & { roomContext?: NodePlatformRoomContext<TMeta> };
 
 export class NodePlatform<
-    TAuthorize extends IOAuthorize<any, any> | null = null,
+    TAuthorize extends IOAuthorize<any, any> = IOAuthorize<any, any>,
     TMeta extends Record<string, Json> = {},
 > extends AbstractPlatform<
     NodeWebSocket<TAuthorize>,
@@ -38,7 +38,6 @@ export class NodePlatform<
             secret: true;
         };
         handleMode: "io";
-        requireAuth: false;
         registrationMode: WebSocketRegistrationMode;
         listeners: {
             onRoomDestroyed: true;
@@ -72,7 +71,6 @@ export class NodePlatform<
             },
             handleMode: "io" as const,
             registrationMode: mode,
-            requireAuth: false as const,
             listeners: {
                 onRoomDestroyed: true as const,
                 onRoomMessage: true as const,

--- a/packages/platform-node/src/NodeWebSocket.ts
+++ b/packages/platform-node/src/NodeWebSocket.ts
@@ -22,11 +22,11 @@ export interface NodeWebSocketEventMap {
 export type NodeWebSocketConfig = AbstractWebSocketConfig;
 
 export class NodeWebSocket<
-    TAuthorize extends IOAuthorize<any, any> | null = null,
+    TAuthorize extends IOAuthorize<any, any> = IOAuthorize<any, any>,
 > extends AbstractWebSocket<WebSocket> {
     private _sessionId: string | null = null;
     private _state: WebSocketSerializedState;
-    private _user: InferIOAuthorizeUser<TAuthorize> = null as InferIOAuthorizeUser<TAuthorize>;
+    private _user: InferIOAuthorizeUser<TAuthorize> | null = null;
 
     public set presence(presence: JsonObject | null) {
         this._state.presence = presence;
@@ -37,13 +37,15 @@ export class NodeWebSocket<
     }
 
     public get session(): WebSocketSession<TAuthorize> {
-        const sessionId = this.sessionId;
-        const state = this._state;
         const user = this._user;
 
+        if (!user) {
+            throw new Error("WebSocket is not authorized");
+        }
+
         return {
-            ...state,
-            id: sessionId,
+            ...this._state,
+            id: this.sessionId,
             user,
             webSocket: this,
         };
@@ -65,6 +67,10 @@ export class NodeWebSocket<
 
     public set state(state: WebSocketSerializedState) {
         this._state = state;
+    }
+
+    public get user(): InferIOAuthorizeUser<TAuthorize> | null {
+        return this._user;
     }
 
     public set user(user: InferIOAuthorizeUser<TAuthorize>) {

--- a/packages/platform-node/src/platformNode.ts
+++ b/packages/platform-node/src/platformNode.ts
@@ -11,7 +11,7 @@ import { toRequest } from "./utils/toRequest";
 export type PlatformNodeCreateIOParams<
     TMeta extends Record<string, Json> = {},
     TContext extends Record<string, any> = {},
-    TUser extends BaseUser | null = null,
+    TUser extends BaseUser = BaseUser,
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
 > = Id<
     NodePlatformConfig<TMeta> &
@@ -24,7 +24,7 @@ export type PlatformNodeCreateIOParams<
             >,
             "authorize" | "context" | "platform"
         > & {
-            authorize?: PluvIOAuthorize<
+            authorize: PluvIOAuthorize<
                 NodePlatform<IOAuthorize<TUser, TContext>, TMeta>,
                 TUser,
                 NodeAuthorizeContext
@@ -37,10 +37,10 @@ export type PlatformNodeCreateIOParams<
 export const platformNode = <
     TMeta extends Record<string, Json> = {},
     TContext extends Record<string, any> = {},
-    TUser extends BaseUser | null = null,
+    TUser extends BaseUser = BaseUser,
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<NoopCrdtDocFactory>,
 >(
-    config: PlatformNodeCreateIOParams<TMeta, TContext, TUser, TCrdt> = {},
+    config: PlatformNodeCreateIOParams<TMeta, TContext, TUser, TCrdt>,
 ): CreateIOParams<NodePlatform<IOAuthorize<TUser, TContext>, TMeta>, TContext, TUser, TCrdt> => {
     const { authorize, context, crdt, debug, limits, origin } = config;
 

--- a/packages/platform-pluv/src/PluvPlatform.ts
+++ b/packages/platform-pluv/src/PluvPlatform.ts
@@ -53,7 +53,6 @@ export class PluvPlatform<
         };
         handleMode: "fetch";
         registrationMode: "attached";
-        requireAuth: true;
         listeners: {
             onRoomDestroyed: true;
             onRoomMessage: false;
@@ -72,7 +71,6 @@ export class PluvPlatform<
         },
         handleMode: "fetch" as const,
         registrationMode: "attached" as const,
-        requireAuth: true as const,
         listeners: {
             onRoomDestroyed: true as const,
             onRoomMessage: false as const,

--- a/packages/types/src/pluv/shared.ts
+++ b/packages/types/src/pluv/shared.ts
@@ -105,9 +105,7 @@ export type IOAuthorize<
           secret?: string;
           user: InputZodLike<TUser>;
       }
-    | ((
-          context: TContext,
-      ) => {
+    | ((context: TContext) => {
           secret?: string;
           user: InputZodLike<TUser>;
       });

--- a/packages/types/src/pluv/shared.ts
+++ b/packages/types/src/pluv/shared.ts
@@ -67,7 +67,7 @@ export type BaseIOEventRecord<TAuthorize extends IOAuthorize<any, any>> = {
         connectionId: string;
         presence: JsonObject;
         timers: { presence: number | null };
-        user: NonNullable<Id<InferIOAuthorizeUser<TAuthorize>>>;
+        user: Id<InferIOAuthorizeUser<TAuthorize>>;
     };
 };
 
@@ -87,34 +87,30 @@ export type GetEventMessage<
 
 export type InferIOAuthorize<TIO extends IOLike<any, any, any>> =
     TIO extends IOLike<infer IAuthorize, any, any>
-        ? InferIOAuthorizeUser<IAuthorize> extends BaseUser
-            ? { user: InputZodLike<InferIOAuthorizeUser<IAuthorize>> }
-            : null
+        ? { user: InputZodLike<InferIOAuthorizeUser<IAuthorize>> }
         : never;
 
-export type InferIOAuthorizeUser<TAuthorize extends IOAuthorize<any, any> | null> =
-    TAuthorize extends IOAuthorize<infer IUser, any> ? IUser : null;
+export type InferIOAuthorizeUser<TAuthorize extends IOAuthorize<any, any>> =
+    TAuthorize extends IOAuthorize<infer IUser, any> ? IUser : never;
 
 export type InputZodLike<TData extends JsonObject> = {
     parse: (data: unknown) => TData;
 } & ({ _input: TData } | { _zod: { input: TData } });
 
 export type IOAuthorize<
-    TUser extends BaseUser | null = any,
+    TUser extends BaseUser = any,
     TContext extends Record<string, unknown> = {},
 > =
-    | (TUser extends BaseUser
-          ? {
-                secret?: string;
-                user: InputZodLike<TUser>;
-            }
-          : null)
-    | ((context: TContext) => TUser extends BaseUser
-          ? {
-                secret?: string;
-                user: InputZodLike<TUser>;
-            }
-          : null);
+    | {
+          secret?: string;
+          user: InputZodLike<TUser>;
+      }
+    | ((
+          context: TContext,
+      ) => {
+          secret?: string;
+          user: InputZodLike<TUser>;
+      });
 
 export type IOAuthorizeEventMessage<TIO extends IOLike> = {
     connectionId: string;
@@ -143,7 +139,7 @@ export interface IORouterLike<TEvents extends Record<string, ProcedureLike<any, 
 }
 
 export interface IOLike<
-    TAuthorize extends IOAuthorize<any, any> | null = null,
+    TAuthorize extends IOAuthorize<any, any> = IOAuthorize<any, any>,
     TCrdt extends CrdtLibraryType<any> = CrdtLibraryType<any>,
     TEvents extends Record<string, ProcedureLike<any, any>> = {},
 > extends IORouterLike<TEvents> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -945,6 +945,9 @@ importers:
       vitest:
         specifier: ^5.0.0
         version: 5.0.0(@types/node@26.5.1)(vite@8.3.0(@types/node@26.5.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13))
+      zod:
+        specifier: ^4.6.2
+        version: 4.6.2
 
 packages:
 

--- a/tests/types/src/has-crdt.test.tsx
+++ b/tests/types/src/has-crdt.test.tsx
@@ -2,8 +2,17 @@ import { infer, createClient } from "@pluv/client";
 import { yjs } from "@pluv/crdt-yjs";
 import { createIO } from "@pluv/io";
 import { platformCloudflare } from "@pluv/platform-cloudflare";
+import { z } from "zod";
 
-const io = createIO(platformCloudflare({ crdt: yjs }));
+const io = createIO(
+    platformCloudflare({
+        authorize: {
+            secret: "test-secret",
+            user: z.object({ id: z.string() }),
+        },
+        crdt: yjs,
+    }),
+);
 
 // @ts-expect-error
 const ioServer = io.server();
@@ -16,6 +25,15 @@ io.server({
 });
 
 const types = infer((i) => ({ io: i<typeof ioServer> }));
+createClient({
+    authEndpoint: () => "",
+    types,
+    initialStorage: yjs.doc((t) => ({
+        messages: t.array<string>("messages"),
+    })),
+});
+
+// @ts-expect-error authEndpoint is required
 createClient({
     types,
     initialStorage: yjs.doc((t) => ({

--- a/tests/types/src/no-crdt.test.tsx
+++ b/tests/types/src/no-crdt.test.tsx
@@ -2,8 +2,16 @@ import { infer as clientInfer, createClient } from "@pluv/client";
 import { yjs } from "@pluv/crdt-yjs";
 import { createIO } from "@pluv/io";
 import { platformCloudflare } from "@pluv/platform-cloudflare";
+import { z } from "zod";
 
-const io = createIO(platformCloudflare({}));
+const io = createIO(
+    platformCloudflare({
+        authorize: {
+            secret: "test-secret",
+            user: z.object({ id: z.string() }),
+        },
+    }),
+);
 
 const ioServer = io.server({
     // @ts-expect-error
@@ -12,9 +20,13 @@ const ioServer = io.server({
 
 const types = clientInfer((i) => ({ io: i<typeof ioServer> }));
 createClient({
+    authEndpoint: () => "",
     types,
     // @ts-expect-error
     initialStorage: yjs.doc((t) => ({
         messages: t.array<string>("messages"),
     })),
 });
+
+// @ts-expect-error authorize is required
+createIO(platformCloudflare({}));

--- a/tests/types/src/types.test.tsx
+++ b/tests/types/src/types.test.tsx
@@ -83,15 +83,25 @@ room.subscribe.storage((storage) => {
 });
 
 room.subscribe.connection((event) => {
-    expectTypeOf<typeof event.authorization.user>().toExtend<{ id: string } | null>();
+    expectTypeOf<typeof event.authorization.user>().toEqualTypeOf<{ id: string } | null>();
+});
+room.subscribe.myself((myself) => {
+    expectTypeOf<typeof myself>().toExtend<{
+        user: { id: string };
+    } | null>();
+    if (myself) {
+        expectTypeOf(myself.user).toEqualTypeOf<{ id: string }>();
+        // @ts-expect-error user is non-null when myself is set
+        expectTypeOf(myself.user).toEqualTypeOf<null>();
+    }
 });
 room.subscribe.other("example-connection-id", (value) => {
     const user = value?.user ?? null;
 
-    expectTypeOf<typeof user>().toExtend<{ id: string } | null>();
+    expectTypeOf<typeof user>().toEqualTypeOf<{ id: string } | null>();
 });
 room.subscribe.others((others, event) => {
-    expectTypeOf<(typeof others)[number]["user"]>().toExtend<{ id: string }>();
+    expectTypeOf<(typeof others)[number]["user"]>().toEqualTypeOf<{ id: string }>();
     expectTypeOf<(typeof event)["kind"]>().toExtend<
         "sync" | "clear" | "enter" | "leave" | "update"
     >();

--- a/tests/unit/package.json
+++ b/tests/unit/package.json
@@ -24,6 +24,7 @@
         "@pluv/tsconfig": "workspace:^",
         "@types/node": "^26.5.1",
         "typescript": "^7.0.2",
-        "vitest": "^5.0.0"
+        "vitest": "^5.0.0",
+        "zod": "^4.6.2"
     }
 }

--- a/tests/unit/src/CloudflarePlatform.persistence.test.ts
+++ b/tests/unit/src/CloudflarePlatform.persistence.test.ts
@@ -1,14 +1,15 @@
 import { yjs } from "@pluv/crdt-yjs";
-import { createIO } from "@pluv/io";
 import { PersistenceCloudflareTransactionalStorage } from "@pluv/persistence-cloudflare-transactional-storage";
 import { platformCloudflare } from "@pluv/platform-cloudflare";
 import { beforeAll, describe, expect, it } from "vitest";
 import {
+    createAuthorizedIO,
     createMockDurableObjectState,
     deferred,
     encodedStateWithContent,
+    registerAuthorized,
+    testAuthorize,
     TestPersistence,
-    TestPlatform,
     TestSocket,
 } from "./__utils__";
 
@@ -27,7 +28,7 @@ beforeAll(() => {
 
 describe("CloudflarePlatform persistence", () => {
     it("uses Durable Object storage after initialize, not the in-memory default", () => {
-        const { platform } = platformCloudflare();
+        const { platform } = platformCloudflare({ authorize: testAuthorize });
         const initialized = platform().initialize({
             roomContext: { env: {}, state: createMockDurableObjectState() },
         });
@@ -36,7 +37,7 @@ describe("CloudflarePlatform persistence", () => {
     });
 
     it("keeps $updateStorage writes across a new platform() after hibernation", async () => {
-        const { platform } = platformCloudflare();
+        const { platform } = platformCloudflare({ authorize: testAuthorize });
         const state = createMockDurableObjectState();
         const roomContext = { env: {}, state };
 
@@ -56,7 +57,7 @@ describe("CloudflarePlatform persistence", () => {
 
         await persistence.setStorageState("home-page", "custom");
 
-        const { platform } = platformCloudflare({ persistence });
+        const { platform } = platformCloudflare({ authorize: testAuthorize, persistence });
         const initialized = platform().initialize({
             roomContext: { env: {}, state: createMockDurableObjectState() },
         });
@@ -66,7 +67,7 @@ describe("CloudflarePlatform persistence", () => {
     });
 
     it("loads Durable Object storage after wake instead of webhook or client seed", async () => {
-        const { platform } = platformCloudflare();
+        const { platform } = platformCloudflare({ authorize: testAuthorize });
         const state = createMockDurableObjectState();
         const roomContext = { env: {}, state };
         const roomId = "home-page";
@@ -79,13 +80,12 @@ describe("CloudflarePlatform persistence", () => {
         await beforeHibernation.persistence.setStorageState(roomId, doSnapshot);
 
         const afterHibernation = platform().initialize({ roomContext });
-        const io = createIO({
+        const io = createAuthorizedIO({
             crdt: yjs,
-            platform: () =>
-                new TestPlatform({
-                    mode: "detached",
-                    persistence: afterHibernation.persistence,
-                }),
+            platform: {
+                mode: "detached",
+                persistence: afterHibernation.persistence,
+            },
         });
         const server = io.server({
             getInitialStorage: () => {
@@ -97,7 +97,7 @@ describe("CloudflarePlatform persistence", () => {
         const room = server.createRoom(roomId, { env: {}, state } as never);
         const socket = new TestSocket("session-1");
 
-        await room.register(socket);
+        await registerAuthorized(room, socket, { io });
         expect(reads).toBe(0);
 
         webhook.resolve(encodedStateWithContent("webhook"));

--- a/tests/unit/src/IORoom.broadcastFanout.test.ts
+++ b/tests/unit/src/IORoom.broadcastFanout.test.ts
@@ -1,6 +1,5 @@
-import { createIO } from "@pluv/io";
 import { describe, expect, it } from "vitest";
-import { TestPlatform, TestSocket, tick } from "./__utils__";
+import { createAuthorizedIO, registerAuthorized, TestSocket, tick } from "./__utils__";
 
 type Room = {
     onMessage: (socket: TestSocket) => (event: { data: string }) => Promise<void>;
@@ -23,16 +22,16 @@ const send = async (room: Room, socket: TestSocket, type: string, data: unknown)
 
 describe("IORoom broadcast fan-out", () => {
     it("still delivers to healthy sockets when another send throws", async () => {
-        const io = createIO({
-            platform: () => new TestPlatform({ mode: "detached" }),
+        const io = createAuthorizedIO({
+            platform: { mode: "detached" },
         });
         const server = io.server();
         const room = server.createRoom("fanout");
         const healthy = new TestSocket("session-healthy");
         const broken = new TestSocket("session-broken");
 
-        await room.register(healthy);
-        await room.register(broken);
+        await registerAuthorized(room, healthy, { io });
+        await registerAuthorized(room, broken, { io });
         await send(room, healthy, "$initializeSession", { presence: {}, update: null });
         await send(room, broken, "$initializeSession", { presence: {}, update: null });
 

--- a/tests/unit/src/IORoom.hibernation.test.ts
+++ b/tests/unit/src/IORoom.hibernation.test.ts
@@ -1,8 +1,13 @@
 import { yjs } from "@pluv/crdt-yjs";
-import { createIO } from "@pluv/io";
 import { applyUpdate, Doc as YDoc, encodeStateAsUpdate, encodeStateVector } from "yjs";
 import { describe, expect, it, vi } from "vitest";
-import { encodedStateWithContent, TestPersistence, TestPlatform, TestSocket } from "./__utils__";
+import {
+    createAuthorizedIO,
+    encodedStateWithContent,
+    TestPersistence,
+    TestPlatform,
+    TestSocket,
+} from "./__utils__";
 
 describe("IORoom hibernation", () => {
     it("does not evict a hibernated socket with a recent auto-response ping", async () => {
@@ -14,11 +19,12 @@ describe("IORoom hibernation", () => {
 
         await persistence.setStorageState(roomId, encodedStateWithContent("current"));
 
-        const io = createIO({
+        const io = createAuthorizedIO({
             crdt: yjs,
             platform: () =>
                 new TestPlatform({
                     hibernatedWebSockets: [socket],
+                    hibernatedUsers: new Map([[socket, { id: "session-1" }]]),
                     lastPings: new Map([[socket, now]]),
                     mode: "detached",
                     persistence,

--- a/tests/unit/src/IORoom.persistence.test.ts
+++ b/tests/unit/src/IORoom.persistence.test.ts
@@ -1,8 +1,14 @@
 import { yjs } from "@pluv/crdt-yjs";
-import { createIO } from "@pluv/io";
 import { applyUpdate, Doc as YDoc, encodeStateAsUpdate, encodeStateVector } from "yjs";
 import { describe, expect, it } from "vitest";
-import { encodedStateWithContent, TestPersistence, TestPlatform, TestSocket } from "./__utils__";
+import {
+    createAuthorizedIO,
+    encodedStateWithContent,
+    registerAuthorized,
+    TestPersistence,
+    TestPlatform,
+    TestSocket,
+} from "./__utils__";
 
 const ROOM_ID = "repeated-persistence";
 
@@ -52,9 +58,9 @@ describe("IORoom repeated persistence", () => {
     it("persists edits made after restoring an externally saved document", async () => {
         let externalStorage = encodedStateWithContent("initial");
 
-        const io = createIO({
+        const io = createAuthorizedIO({
             crdt: yjs,
-            platform: () => new TestPlatform({ mode: "detached" }),
+            platform: { mode: "detached" },
         });
         const server = io.server({
             getInitialStorage: () => Promise.resolve(externalStorage),
@@ -66,7 +72,7 @@ describe("IORoom repeated persistence", () => {
         const firstRoom = server.createRoom(ROOM_ID);
         const firstSocket = new TestSocket("session-1");
 
-        await firstRoom.register(firstSocket);
+        await registerAuthorized(firstRoom, firstSocket, { io });
         await updateStorage(
             firstRoom,
             firstSocket,
@@ -79,7 +85,7 @@ describe("IORoom repeated persistence", () => {
         const secondRoom = server.createRoom(ROOM_ID);
         const secondSocket = new TestSocket("session-2");
 
-        await secondRoom.register(secondSocket);
+        await registerAuthorized(secondRoom, secondSocket, { io });
         await updateStorage(
             secondRoom,
             secondSocket,
@@ -92,7 +98,7 @@ describe("IORoom repeated persistence", () => {
         const thirdRoom = server.createRoom(ROOM_ID);
         const thirdSocket = new TestSocket("session-3");
 
-        await thirdRoom.register(thirdSocket);
+        await registerAuthorized(thirdRoom, thirdSocket, { io });
 
         expect(decodeText(getRegisteredState(thirdSocket))).toBe("initial first second");
     });
@@ -103,7 +109,7 @@ describe("IORoom repeated persistence", () => {
         let initialStorageReads = 0;
         const persistence = new TestPersistence();
 
-        const io = createIO({
+        const io = createAuthorizedIO({
             crdt: yjs,
             platform: () =>
                 new TestPlatform({
@@ -137,7 +143,7 @@ describe("IORoom repeated persistence", () => {
         const firstRoom = server.createRoom(ROOM_ID);
         const firstSocket = new TestSocket("session-1");
 
-        await firstRoom.register(firstSocket);
+        await registerAuthorized(firstRoom, firstSocket, { io });
         await updateStorage(
             firstRoom,
             firstSocket,
@@ -153,7 +159,7 @@ describe("IORoom repeated persistence", () => {
 
         const secondSocket = new TestSocket("session-2");
 
-        await firstWake.register(secondSocket);
+        await registerAuthorized(firstWake, secondSocket, { io });
         expect(decodeText(getRegisteredState(secondSocket))).toBe("initial first");
         expect(initialStorageReads).toBe(2);
 
@@ -172,7 +178,7 @@ describe("IORoom repeated persistence", () => {
 
         const thirdSocket = new TestSocket("session-3");
 
-        await secondWake.register(thirdSocket);
+        await registerAuthorized(secondWake, thirdSocket, { io });
 
         expect(decodeText(getRegisteredState(thirdSocket))).toBe("initial first second");
         expect(decodeText(externalStorage)).toBe("initial first second");

--- a/tests/unit/src/IORoom.presence.test.ts
+++ b/tests/unit/src/IORoom.presence.test.ts
@@ -1,6 +1,5 @@
-import { createIO } from "@pluv/io";
 import { describe, expect, it } from "vitest";
-import { TestPlatform, TestSocket } from "./__utils__";
+import { createAuthorizedIO, registerAuthorized, TestSocket } from "./__utils__";
 
 type Room = {
     onMessage: (socket: TestSocket) => (event: { data: string }) => Promise<void>;
@@ -52,24 +51,24 @@ const getOthers = async (room: Room, socket: TestSocket): Promise<void> => {
 
 describe("IORoom presence", () => {
     const createRoom = (roomId: string = "presence") => {
-        const io = createIO({
-            platform: () => new TestPlatform({ mode: "detached" }),
+        const io = createAuthorizedIO({
+            platform: { mode: "detached" },
         });
         const server = io.server();
         const room = server.createRoom(roomId);
 
-        return room;
+        return { io, room };
     };
 
     it("persists initialize presence for later $getOthers and partial patches", async () => {
-        const room = createRoom();
+        const { io, room } = createRoom();
         const first = new TestSocket("session-1");
         const second = new TestSocket("session-2");
 
-        await room.register(first);
+        await registerAuthorized(room, first, { io });
         await initializeSession(room, first, { cursor: 1, name: "ada" });
 
-        await room.register(second);
+        await registerAuthorized(room, second, { io });
         await initializeSession(room, second, { cursor: 0, name: "bob" });
         await getOthers(room, second);
 
@@ -94,14 +93,14 @@ describe("IORoom presence", () => {
     });
 
     it("still broadcasts $userJoined with the initialize presence payload", async () => {
-        const room = createRoom("presence-join");
+        const { io, room } = createRoom("presence-join");
         const first = new TestSocket("session-1");
         const second = new TestSocket("session-2");
 
-        await room.register(first);
+        await registerAuthorized(room, first, { io });
         await initializeSession(room, first, { cursor: 0, name: "ada" });
 
-        await room.register(second);
+        await registerAuthorized(room, second, { io });
         await initializeSession(room, second, { cursor: 9, name: "bob" });
 
         expect(lastMessage(first, "$userJoined").data).toMatchObject({

--- a/tests/unit/src/IORoom.procedureError.test.ts
+++ b/tests/unit/src/IORoom.procedureError.test.ts
@@ -1,6 +1,5 @@
-import { createIO } from "@pluv/io";
 import { describe, expect, it } from "vitest";
-import { TestPlatform, TestSocket } from "./__utils__";
+import { createAuthorizedIO, registerAuthorized, TestSocket } from "./__utils__";
 
 type Room = {
     onMessage: (socket: TestSocket) => (event: { data: string }) => Promise<void>;
@@ -23,8 +22,8 @@ const send = async (room: Room, socket: TestSocket, type: string, data: unknown)
 
 describe("IORoom procedure errors", () => {
     it("sends $error when a procedure resolver throws", async () => {
-        const io = createIO({
-            platform: () => new TestPlatform({ mode: "detached" }),
+        const io = createAuthorizedIO({
+            platform: { mode: "detached" },
         });
         const server = io.server({
             router: io.router({
@@ -36,22 +35,22 @@ describe("IORoom procedure errors", () => {
         const room = server.createRoom("procedure-throw");
         const socket = new TestSocket("session-1");
 
-        await room.register(socket);
+        await registerAuthorized(room, socket, { io });
         await send(room, socket, "boom", {});
 
         expect(lastMessage(socket, "$error").data.message).toBe("procedure exploded");
     });
 
     it("sends $error when presence exceeds the size limit", async () => {
-        const io = createIO({
+        const io = createAuthorizedIO({
             limits: { presenceMaxSize: 32 },
-            platform: () => new TestPlatform({ mode: "detached" }),
+            platform: { mode: "detached" },
         });
         const server = io.server();
         const room = server.createRoom("presence-limit");
         const socket = new TestSocket("session-1");
 
-        await room.register(socket);
+        await registerAuthorized(room, socket, { io });
         await send(room, socket, "$initializeSession", { presence: {}, update: null });
         await send(room, socket, "$updatePresence", {
             presence: { note: "x".repeat(64) },
@@ -61,8 +60,8 @@ describe("IORoom procedure errors", () => {
     });
 
     it("still sends $error for invalid procedure input", async () => {
-        const io = createIO({
-            platform: () => new TestPlatform({ mode: "detached" }),
+        const io = createAuthorizedIO({
+            platform: { mode: "detached" },
         });
         const server = io.server({
             router: io.router({
@@ -87,7 +86,7 @@ describe("IORoom procedure errors", () => {
         const room = server.createRoom("invalid-input");
         const socket = new TestSocket("session-1");
 
-        await room.register(socket);
+        await registerAuthorized(room, socket, { io });
         await send(room, socket, "echo", { message: 1 });
 
         expect(lastMessage(socket, "$error").data.message).toBe("Expected { message: string }");

--- a/tests/unit/src/IORoom.storageInit.test.ts
+++ b/tests/unit/src/IORoom.storageInit.test.ts
@@ -1,15 +1,15 @@
 import { loro } from "@pluv/crdt-loro";
 import { yjs } from "@pluv/crdt-yjs";
-import { createIO } from "@pluv/io";
 import { LoroDoc } from "loro-crdt";
 import { applyUpdate, Doc as YDoc, encodeStateAsUpdate, encodeStateVector } from "yjs";
 import { describe, expect, it } from "vitest";
 import {
+    createAuthorizedIO,
     deferred,
     encodedLoroStateWithContent,
     encodedStateWithContent,
+    registerAuthorized,
     TestPersistence,
-    TestPlatform,
     TestSocket,
     tick,
 } from "./__utils__";
@@ -128,20 +128,20 @@ describe.each(scenarios)("$name IORoom storage init", ({ append, crdt, decode, e
         roomId?: string;
     }) => {
         const persistence = config.persistence ?? new TestPersistence();
-        const io = createIO({
+        const io = createAuthorizedIO({
             crdt,
-            platform: () => new TestPlatform({ mode: "detached", persistence }),
+            platform: { mode: "detached", persistence },
         });
         const server = io.server({ getInitialStorage: config.getInitialStorage });
         const room = server.createRoom(config.roomId ?? "storage-init");
 
-        return { persistence, room };
+        return { io, persistence, room };
     };
 
     it("keeps delayed webhook state instead of a later client seed", async () => {
         const webhook = deferred<string | null>();
         let reads = 0;
-        const { room } = createRoom({
+        const { io, room } = createRoom({
             getInitialStorage: () => {
                 reads += 1;
 
@@ -149,7 +149,7 @@ describe.each(scenarios)("$name IORoom storage init", ({ append, crdt, decode, e
             },
         });
         const socket = new TestSocket("session-1");
-        const registration = room.register(socket);
+        const registration = registerAuthorized(room, socket, { io });
 
         await tick();
         expect(reads).toBe(1);
@@ -170,7 +170,7 @@ describe.each(scenarios)("$name IORoom storage init", ({ append, crdt, decode, e
 
         await persistence.setStorageState("storage-init", encode("do"));
 
-        const { room } = createRoom({
+        const { io, room } = createRoom({
             getInitialStorage: () => {
                 reads += 1;
 
@@ -180,7 +180,7 @@ describe.each(scenarios)("$name IORoom storage init", ({ append, crdt, decode, e
         });
         const socket = new TestSocket("session-1");
 
-        await room.register(socket);
+        await registerAuthorized(room, socket, { io });
         expect(reads).toBe(0);
 
         webhook.resolve(encode("webhook"));
@@ -192,11 +192,11 @@ describe.each(scenarios)("$name IORoom storage init", ({ append, crdt, decode, e
 
     it("allows a client seed when the delayed webhook is null", async () => {
         const webhook = deferred<string | null>();
-        const { persistence, room } = createRoom({
+        const { io, persistence, room } = createRoom({
             getInitialStorage: () => webhook.promise,
         });
         const socket = new TestSocket("session-1");
-        const registration = room.register(socket);
+        const registration = registerAuthorized(room, socket, { io });
 
         await tick();
         webhook.resolve(null);
@@ -211,7 +211,7 @@ describe.each(scenarios)("$name IORoom storage init", ({ append, crdt, decode, e
     it("hydrates two overlapping first connections from one webhook fetch", async () => {
         const webhook = deferred<string | null>();
         let reads = 0;
-        const { room } = createRoom({
+        const { io, room } = createRoom({
             getInitialStorage: () => {
                 reads += 1;
 
@@ -220,7 +220,10 @@ describe.each(scenarios)("$name IORoom storage init", ({ append, crdt, decode, e
         });
         const first = new TestSocket("session-1");
         const second = new TestSocket("session-2");
-        const registrations = Promise.all([room.register(first), room.register(second)]);
+        const registrations = Promise.all([
+            registerAuthorized(room, first, { io }),
+            registerAuthorized(room, second, { io }),
+        ]);
 
         await tick();
         expect(reads).toBe(1);
@@ -241,14 +244,17 @@ describe.each(scenarios)("$name IORoom storage init", ({ append, crdt, decode, e
 
     it("ignores a second vacant client seed while the first persist is in flight", async () => {
         const persistence = new GatedPersistence();
-        const { room } = createRoom({
+        const { io, room } = createRoom({
             getInitialStorage: () => Promise.resolve(null),
             persistence,
         });
         const first = new TestSocket("session-1");
         const second = new TestSocket("session-2");
 
-        await Promise.all([room.register(first), room.register(second)]);
+        await Promise.all([
+            registerAuthorized(room, first, { io }),
+            registerAuthorized(room, second, { io }),
+        ]);
 
         const firstInit = initializeSession(room, first, encode("alpha"));
         const secondInit = initializeSession(room, second, encode("beta"));
@@ -267,12 +273,12 @@ describe.each(scenarios)("$name IORoom storage init", ({ append, crdt, decode, e
     });
 
     it("does not apply $updateStorage origin $initialized after a claimed load", async () => {
-        const { persistence, room } = createRoom({
+        const { io, persistence, room } = createRoom({
             getInitialStorage: () => Promise.resolve(encode("server")),
         });
         const socket = new TestSocket("session-1");
 
-        await room.register(socket);
+        await registerAuthorized(room, socket, { io });
         await initializeSession(room, socket, encode("client"));
         await updateStorage(room, socket, "$initialized", encode("client"));
 
@@ -281,12 +287,12 @@ describe.each(scenarios)("$name IORoom storage init", ({ append, crdt, decode, e
     });
 
     it("still applies $updateStorage origin null", async () => {
-        const { persistence, room } = createRoom({
+        const { io, persistence, room } = createRoom({
             getInitialStorage: () => Promise.resolve(encode("server")),
         });
         const socket = new TestSocket("session-1");
 
-        await room.register(socket);
+        await registerAuthorized(room, socket, { io });
         await initializeSession(room, socket, encode("client"));
 
         const base = lastMessage(socket, "$storageReceived").data.state as string;
@@ -299,13 +305,16 @@ describe.each(scenarios)("$name IORoom storage init", ({ append, crdt, decode, e
     });
 
     it("merges two overlapping live origin-null updates", async () => {
-        const { persistence, room } = createRoom({
+        const { io, persistence, room } = createRoom({
             getInitialStorage: () => Promise.resolve(encode("base")),
         });
         const first = new TestSocket("session-1");
         const second = new TestSocket("session-2");
 
-        await Promise.all([room.register(first), room.register(second)]);
+        await Promise.all([
+            registerAuthorized(room, first, { io }),
+            registerAuthorized(room, second, { io }),
+        ]);
         await initializeSession(room, first, encode("client"));
 
         const base = lastMessage(first, "$storageReceived").data.state as string;

--- a/tests/unit/src/IORoom.teardown.test.ts
+++ b/tests/unit/src/IORoom.teardown.test.ts
@@ -1,12 +1,12 @@
 import { yjs } from "@pluv/crdt-yjs";
-import { createIO } from "@pluv/io";
 import { describe, expect, it } from "vitest";
 import type { Deferred } from "./__utils__";
 import {
+    createAuthorizedIO,
     deferred,
     encodedStateWithContent,
     isEmptyEncodedState,
-    TestPlatform,
+    registerAuthorized,
     TestSocket,
     tick,
     waitUntil,
@@ -26,7 +26,7 @@ const setupRoom = (roomId: string) => {
 
     let shouldBlock = true;
 
-    const io = createIO({ crdt: yjs, platform: () => new TestPlatform() });
+    const io = createAuthorizedIO({ crdt: yjs });
     const server = io.server({
         getInitialStorage: () => Promise.resolve(seeded),
         onStorageDestroyed: async ({ encodedState }) => {
@@ -40,14 +40,14 @@ const setupRoom = (roomId: string) => {
         },
     });
 
-    return { destroyed, gate, room: server.createRoom(roomId), seeded };
+    return { destroyed, gate, io, room: server.createRoom(roomId), seeded };
 };
 
 describe("IORoom teardown", () => {
     it("persists storage once, and never persists an empty document", async () => {
-        const { destroyed, gate, room } = setupRoom("overlapping-teardowns");
+        const { destroyed, gate, io, room } = setupRoom("overlapping-teardowns");
 
-        await room.register(new TestSocket("session-1"));
+        await registerAuthorized(room, new TestSocket("session-1"), { io });
 
         // Held open inside its onStorageDestroyed webhook.
         const firstTeardown = room.evictAll();
@@ -67,9 +67,9 @@ describe("IORoom teardown", () => {
     });
 
     it("does not hand a late connection an empty document while teardown is in-flight", async () => {
-        const { destroyed, gate, room } = setupRoom("register-during-teardown");
+        const { destroyed, gate, io, room } = setupRoom("register-during-teardown");
 
-        await room.register(new TestSocket("session-1"));
+        await registerAuthorized(room, new TestSocket("session-1"), { io });
 
         const teardown = room.evictAll();
 
@@ -77,7 +77,7 @@ describe("IORoom teardown", () => {
 
         // The room is mid-teardown, so its doc has already been cleared.
         const late = new TestSocket("session-2");
-        const registration = room.register(late);
+        const registration = registerAuthorized(room, late, { io });
 
         await tick(2);
 

--- a/tests/unit/src/__utils__/TestPlatform.ts
+++ b/tests/unit/src/__utils__/TestPlatform.ts
@@ -7,7 +7,7 @@ import type {
     WebSocketSerializedState,
 } from "@pluv/io";
 import { AbstractPlatform } from "@pluv/io";
-import type { IOAuthorize } from "@pluv/types";
+import type { BaseUser, IOAuthorize } from "@pluv/types";
 import crypto from "node:crypto";
 import { TestSocket, TestWebSocket } from "./TestWebSocket";
 
@@ -17,6 +17,8 @@ export type TestPlatformConfig = {
     pubSub?: AbstractPubSub;
     /** Sockets reported as pre-existing, as Cloudflare does after waking from hibernation. */
     hibernatedWebSockets?: readonly TestSocket[];
+    /** Users attached to hibernated sockets (mirrors Cloudflare attachment `user`). */
+    hibernatedUsers?: ReadonlyMap<TestSocket, BaseUser>;
     lastPings?: ReadonlyMap<TestSocket, number>;
     serializedStates?: ReadonlyMap<TestSocket, WebSocketSerializedState>;
 };
@@ -27,7 +29,7 @@ export type TestPlatformConfig = {
  * `onStorageDestroyed` are unsupported.
  */
 export class TestPlatform<
-    TAuthorize extends IOAuthorize<any, any> | null = null,
+    TAuthorize extends IOAuthorize<any, any> = IOAuthorize<any, any>,
 > extends AbstractPlatform<
     TestWebSocket<TAuthorize>,
     {},
@@ -35,7 +37,6 @@ export class TestPlatform<
     {
         authorize: { secret: true };
         handleMode: "io";
-        requireAuth: false;
         registrationMode: WebSocketRegistrationMode;
         listeners: {
             onRoomDestroyed: true;
@@ -53,6 +54,7 @@ export class TestPlatform<
     public readonly _name = "platformTest";
 
     private readonly _hibernatedWebSockets: readonly TestSocket[];
+    private readonly _hibernatedUsers: ReadonlyMap<TestSocket, BaseUser>;
     private readonly _lastPings: ReadonlyMap<TestSocket, number>;
     private readonly _mode: WebSocketRegistrationMode;
     private readonly _serializedStates: ReadonlyMap<TestSocket, WebSocketSerializedState>;
@@ -62,6 +64,7 @@ export class TestPlatform<
     constructor(config: TestPlatformConfig = {}) {
         const {
             hibernatedWebSockets = [],
+            hibernatedUsers = new Map<TestSocket, BaseUser>(),
             lastPings = new Map<TestSocket, number>(),
             mode = "attached",
             persistence,
@@ -72,6 +75,7 @@ export class TestPlatform<
         super({ persistence, pubSub });
 
         this._hibernatedWebSockets = hibernatedWebSockets;
+        this._hibernatedUsers = hibernatedUsers;
         this._lastPings = lastPings;
         this._mode = mode;
         this._serializedStates = serializedStates;
@@ -80,7 +84,6 @@ export class TestPlatform<
             authorize: { secret: true as const },
             handleMode: "io" as const,
             registrationMode: mode,
-            requireAuth: false as const,
             listeners: {
                 onRoomDestroyed: true as const,
                 onStorageDestroyed: true as const,
@@ -111,8 +114,10 @@ export class TestPlatform<
             room: config.room,
         });
         const serializedState = this._serializedStates.get(webSocket);
+        const user = this._hibernatedUsers.get(webSocket);
 
         if (serializedState) converted.state = serializedState;
+        if (user) converted.user = user as any;
         this._wrapped.set(webSocket, converted);
 
         return converted;
@@ -137,6 +142,7 @@ export class TestPlatform<
     public initialize(config: AbstractPlatformConfig<{}>): this {
         return new TestPlatform<TAuthorize>({
             hibernatedWebSockets: this._hibernatedWebSockets,
+            hibernatedUsers: this._hibernatedUsers,
             lastPings: this._lastPings,
             mode: this._mode,
             persistence: this.persistence.initialize(config.roomContext),

--- a/tests/unit/src/__utils__/TestWebSocket.ts
+++ b/tests/unit/src/__utils__/TestWebSocket.ts
@@ -46,10 +46,10 @@ export class TestSocket {
 }
 
 export class TestWebSocket<
-    TAuthorize extends IOAuthorize<any, any> | null = null,
+    TAuthorize extends IOAuthorize<any, any> = IOAuthorize<any, any>,
 > extends AbstractWebSocket<TestSocket> {
     private _state: WebSocketSerializedState;
-    private _user: InferIOAuthorizeUser<TAuthorize> = null as InferIOAuthorizeUser<TAuthorize>;
+    private _user: InferIOAuthorizeUser<TAuthorize> | null = null;
 
     public set presence(presence: JsonObject | null) {
         this._state.presence = presence;
@@ -60,10 +60,16 @@ export class TestWebSocket<
     }
 
     public get session(): WebSocketSession<TAuthorize> {
+        const user = this._user;
+
+        if (!user) {
+            throw new Error("WebSocket is not authorized");
+        }
+
         return {
             ...this._state,
             id: this.sessionId,
-            user: this._user,
+            user,
             webSocket: this,
         };
     }
@@ -78,6 +84,10 @@ export class TestWebSocket<
 
     public set state(state: WebSocketSerializedState) {
         this._state = state;
+    }
+
+    public get user(): InferIOAuthorizeUser<TAuthorize> | null {
+        return this._user;
     }
 
     public set user(user: InferIOAuthorizeUser<TAuthorize>) {

--- a/tests/unit/src/__utils__/index.ts
+++ b/tests/unit/src/__utils__/index.ts
@@ -7,6 +7,15 @@ export {
     tick,
     waitUntil,
 } from "./helpers";
+export {
+    TEST_AUTH_SECRET,
+    createAuthorizedIO,
+    createAuthorizedToken,
+    registerAuthorized,
+    testAuthorize,
+    testAuthorizeUser,
+} from "./testAuthorize";
+export type { TestAuthorizeUser } from "./testAuthorize";
 export { TestPersistence } from "./TestPersistence";
 export { TestPlatform } from "./TestPlatform";
 export type { TestPlatformConfig } from "./TestPlatform";

--- a/tests/unit/src/__utils__/testAuthorize.ts
+++ b/tests/unit/src/__utils__/testAuthorize.ts
@@ -57,9 +57,7 @@ export const createAuthorizedToken = async (
     });
 };
 
-export const registerAuthorized = async <
-    TServer extends PluvServer<any, any, any, any, any>,
->(
+export const registerAuthorized = async <TServer extends PluvServer<any, any, any, any, any>>(
     room: InferIORoom<TServer>,
     socket: TestSocket,
     params: {

--- a/tests/unit/src/__utils__/testAuthorize.ts
+++ b/tests/unit/src/__utils__/testAuthorize.ts
@@ -1,0 +1,76 @@
+import type { CreateIOParams, InferIORoom, PluvIO, PluvServer } from "@pluv/io";
+import { createIO } from "@pluv/io";
+import type { BaseUser } from "@pluv/types";
+import { z } from "zod";
+import { TestPlatform } from "./TestPlatform";
+import type { TestPlatformConfig } from "./TestPlatform";
+import type { TestSocket } from "./TestWebSocket";
+
+export const TEST_AUTH_SECRET = "unit-test-auth-secret";
+
+export const testAuthorizeUser = z.object({
+    id: z.string(),
+});
+
+export type TestAuthorizeUser = z.infer<typeof testAuthorizeUser>;
+
+export const testAuthorize = {
+    secret: TEST_AUTH_SECRET,
+    user: testAuthorizeUser,
+} as const;
+
+type TestCreateIOOptions = Omit<
+    CreateIOParams<TestPlatform, {}, TestAuthorizeUser, any>,
+    "authorize" | "platform"
+> & {
+    platform?: TestPlatformConfig | (() => TestPlatform);
+};
+
+export const createAuthorizedIO = <TCrdt extends CreateIOParams<any, any, any, any>["crdt"]>(
+    options: TestCreateIOOptions & { crdt?: TCrdt } = {},
+) => {
+    const { platform, ...rest } = options;
+    const platformFactory =
+        typeof platform === "function"
+            ? platform
+            : () => new TestPlatform(platform ?? { mode: "detached" });
+
+    return createIO({
+        authorize: testAuthorize,
+        platform: platformFactory,
+        ...rest,
+    });
+};
+
+export const createAuthorizedToken = async (
+    io: PluvIO<any, any, any, any>,
+    params: {
+        room: string;
+        user?: TestAuthorizeUser;
+    },
+): Promise<string> => {
+    const { room, user = { id: "test-user" } } = params;
+
+    return await io.createToken({
+        room,
+        user,
+    });
+};
+
+export const registerAuthorized = async <
+    TServer extends PluvServer<any, any, any, any, any>,
+>(
+    room: InferIORoom<TServer>,
+    socket: TestSocket,
+    params: {
+        io: PluvIO<any, any, any, any>;
+        user?: TestAuthorizeUser & BaseUser;
+    },
+): Promise<void> => {
+    const token = await createAuthorizedToken(params.io, {
+        room: room.id,
+        user: params.user ?? { id: socket.id },
+    });
+
+    await room.register(socket, { token });
+};


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/main/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Require authorization for every room connection.

Open (unauthorized) rooms are removed: `createIO` must configure `authorize`, clients must provide an `authEndpoint`, and connections without a valid token are rejected. Session users are always typed from your authorize schema (at least `{ id: string }`), not `null`.