### PR TITLE
fix(io): correct JWT maxAge units and wait for room init

### DIFF
--- a/.changeset/calm-apples-jump.md
+++ b/.changeset/calm-apples-jump.md
@@ -1,0 +1,7 @@
+---
+"@pluv/io": patch
+---
+
+Fix JWT `maxAge` so it is treated as milliseconds (default 60s), and treat invalid/expired tokens as unauthorized instead of throwing during register.
+
+Room registration also waits for room initialization to finish before accepting the connection, so clients are not registered against a room that is still loading storage.

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -184,7 +184,8 @@ export class IORoom<
     }
 
     private get _initialized(): Promise<boolean> {
-        return Promise.resolve(!!this._uninitialize?.then((result) => !!result));
+        if (!this._uninitialize) return Promise.resolve(false);
+        return this._uninitialize.then(() => true);
     }
 
     constructor(id: string, config: IORoomConfig<TPlatform, TAuthorize, TContext, TEvents>) {

--- a/packages/io/src/authorize.ts
+++ b/packages/io/src/authorize.ts
@@ -3,6 +3,7 @@ import type { BaseUser } from "@pluv/types";
 import { EncryptJWT, jwtDecrypt } from "jose";
 import type { AbstractPlatform, InferInitContextType } from "./AbstractPlatform";
 
+/** Default token lifetime: 60 seconds (passed to jose as seconds). */
 const DEFAULT_MAX_AGE_MS = 60_000;
 
 export const getEncryptionKey = async (secret: string): Promise<Uint8Array> => {
@@ -19,6 +20,10 @@ export type JWTEncodeParams<
     TUser extends BaseUser,
     TPlatform extends AbstractPlatform<any, any>,
 > = {
+    /**
+     * Token lifetime in milliseconds. Converted to whole seconds for JWT `exp`.
+     * @default 60_000
+     */
     maxAge?: number;
     room: string;
     user: TUser;
@@ -30,13 +35,17 @@ export interface AuthorizeParams {
 }
 
 export interface AuthorizeModule {
-    decode: <TUser extends BaseUser>(jwt: string) => Promise<TUser | null>;
+    decode: <TUser extends BaseUser>(jwt: string) => Promise<JWT<TUser> | null>;
     encode: <TUser extends BaseUser, TPlatform extends AbstractPlatform<any, any>>(
         params: JWTEncodeParams<TUser, TPlatform>,
     ) => Promise<string>;
 }
 
 const now = () => (Date.now() / 1_000) | 0;
+
+const maxAgeMsToSeconds = (maxAgeMs: number): number => {
+    return Math.max(1, Math.ceil(maxAgeMs / 1_000));
+};
 
 export const authorize = (params: AuthorizeParams) => {
     const { platform, secret } = params;
@@ -55,7 +64,7 @@ export const authorize = (params: AuthorizeParams) => {
         })
             .setProtectedHeader({ alg: "dir", enc: "A256GCM" })
             .setIssuedAt()
-            .setExpirationTime(now() + maxAge)
+            .setExpirationTime(now() + maxAgeMsToSeconds(maxAge))
             .setJti(platform.randomUUID())
             .encrypt(encryptionSecret);
 
@@ -63,13 +72,17 @@ export const authorize = (params: AuthorizeParams) => {
     };
 
     const decode = async <TUser extends BaseUser>(jwt: string): Promise<JWT<TUser> | null> => {
-        const encryptionSecret = await getEncryptionKey(secret);
+        try {
+            const encryptionSecret = await getEncryptionKey(secret);
 
-        const { payload } = await jwtDecrypt(jwt, encryptionSecret, {
-            clockTolerance: 15,
-        });
+            const { payload } = await jwtDecrypt(jwt, encryptionSecret, {
+                clockTolerance: 15,
+            });
 
-        return (payload as any) ?? null;
+            return (payload as unknown as JWT<TUser> | undefined) ?? null;
+        } catch {
+            return null;
+        }
     };
 
     return { decode, encode };

--- a/tests/unit/src/IORoom.initialized.test.ts
+++ b/tests/unit/src/IORoom.initialized.test.ts
@@ -1,12 +1,6 @@
 import { yjs } from "@pluv/crdt-yjs";
 import { describe, expect, it } from "vitest";
-import {
-    createAuthorizedIO,
-    deferred,
-    registerAuthorized,
-    TestSocket,
-    tick,
-} from "./__utils__";
+import { createAuthorizedIO, deferred, registerAuthorized, TestSocket, tick } from "./__utils__";
 
 describe("IORoom initialization", () => {
     it("waits for getInitialStorage before finishing register", async () => {

--- a/tests/unit/src/IORoom.initialized.test.ts
+++ b/tests/unit/src/IORoom.initialized.test.ts
@@ -1,0 +1,40 @@
+import { yjs } from "@pluv/crdt-yjs";
+import { describe, expect, it } from "vitest";
+import {
+    createAuthorizedIO,
+    deferred,
+    registerAuthorized,
+    TestSocket,
+    tick,
+} from "./__utils__";
+
+describe("IORoom initialization", () => {
+    it("waits for getInitialStorage before finishing register", async () => {
+        const webhook = deferred<string | null>();
+        let storageReads = 0;
+        const io = createAuthorizedIO({
+            crdt: yjs,
+            platform: { mode: "detached" },
+        });
+        const server = io.server({
+            getInitialStorage: async () => {
+                storageReads += 1;
+
+                return webhook.promise;
+            },
+        });
+        const room = server.createRoom("init-wait");
+        const socket = new TestSocket("session-1");
+
+        const registration = registerAuthorized(room, socket, { io });
+
+        await tick();
+        expect(storageReads).toBe(1);
+        expect(socket.messages.some((message) => message.type === "$registered")).toBe(false);
+
+        webhook.resolve(null);
+        await registration;
+
+        expect(socket.messages.some((message) => message.type === "$registered")).toBe(true);
+    });
+});


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/main/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fix JWT `maxAge` so it is treated as milliseconds (default 60s), and treat invalid/expired tokens as unauthorized instead of throwing during register.

Room registration also waits for room initialization to finish before accepting the connection, so clients are not registered against a room that is still loading storage.