### PR TITLE
fix(io): count room users in in-memory persistence

### DIFF
--- a/.changeset/bumpy-moons-report.md
+++ b/.changeset/bumpy-moons-report.md
@@ -1,0 +1,7 @@
+---
+"@pluv/io": patch
+---
+
+Fix in-memory persistence reporting the wrong user count for a room.
+
+`getUsersSize` now counts connections in that room instead of how many rooms exist in memory, matching Redis and other persistence backends.

--- a/packages/io/src/Persistence.ts
+++ b/packages/io/src/Persistence.ts
@@ -41,10 +41,6 @@ export class Persistence extends AbstractPersistence {
         return Promise.resolve();
     }
 
-    public getSize(room: string): Promise<number> {
-        return Promise.resolve(this._users.get(room)?.size ?? 0);
-    }
-
     public getStorageState(room: string): Promise<string | null> {
         const storage = this._storages.get(room) ?? null;
 
@@ -66,7 +62,7 @@ export class Persistence extends AbstractPersistence {
     }
 
     public async getUsersSize(room: string): Promise<number> {
-        return this._users.size;
+        return this._users.get(room)?.size ?? 0;
     }
 
     public initialize(roomContext: any): this {


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/main/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Fix in-memory persistence reporting the wrong user count for a room.

`getUsersSize` now counts connections in that room instead of how many rooms exist in memory, matching Redis and other persistence backends.
