### PR TITLE
feat: accept Standard Schema validators

### DIFF
--- a/.changeset/standard-schema-validators.md
+++ b/.changeset/standard-schema-validators.md
@@ -1,0 +1,13 @@
+---
+"@pluv/types": major
+"@pluv/io": major
+"@pluv/client": major
+"@pluv/react": major
+"@pluv/platform-node": major
+"@pluv/platform-cloudflare": major
+"@pluv/platform-pluv": major
+---
+
+Accept any Standard Schema validator for authorize, presence, metadata, and procedure inputs.
+
+Zod still works as before on recent versions (3.24+/4). You can also use Valibot, ArkType, or other Standard Schema–compatible libraries. The old `InputZodLike` duck type (`{ parse, _input }`) is removed — schemas must expose `~standard.validate`.

--- a/apps/docs/content/docs/guides/authorization.mdx
+++ b/apps/docs/content/docs/guides/authorization.mdx
@@ -17,6 +17,8 @@ You can view another example of these via your platform's respective quickstart 
 
 Set the required `authorize` property on your `createIO` config. The `user` schema must always include `id`.
 
+Schemas may be any [Standard Schema](https://standardschema.dev)–compatible library (Zod 3.24+, Valibot 1+, ArkType 2+, and others). The examples below use Zod.
+
 ```ts
 // server/io.ts
 import { createIO } from "@pluv/io";

--- a/docs/authorization.mdx
+++ b/docs/authorization.mdx
@@ -19,6 +19,8 @@ You can view another example of these via your platform's respective quickstart 
 
 Set the required `authorize` property on your `createIO` config. The `user` schema must always include `id`.
 
+Schemas may be any [Standard Schema](https://standardschema.dev)–compatible library (Zod 3.24+, Valibot 1+, ArkType 2+, and others). The examples below use Zod.
+
 ```ts
 // server/io.ts
 import { createIO } from "@pluv/io";

--- a/packages/addon-indexeddb/package.json
+++ b/packages/addon-indexeddb/package.json
@@ -44,6 +44,7 @@
         "./*": "./*"
     },
     "inlinedDependencies": {
+        "@standard-schema/spec": "1.1.0",
         "wonka": "6.3.6"
     }
 }

--- a/packages/client/src/MockedRoom.ts
+++ b/packages/client/src/MockedRoom.ts
@@ -49,6 +49,7 @@ import type {
     InternalSubscriptions,
     PluvClientLimits,
 } from "./types";
+import { parsePluvSchema } from "./utils";
 
 export type MockedRoomEvents<TIO extends IOLike> = Partial<{
     [P in keyof InferIOInput<TIO>]: (data: Id<InferIOInput<TIO>[P]>) => Partial<InferIOOutput<TIO>>;
@@ -164,7 +165,9 @@ export class MockedRoom<
 
             if (!myself) return;
 
-            const parsed = procedure.config.input ? procedure.config.input.parse(data) : data;
+            const parsed = procedure.config.input
+                ? parsePluvSchema(procedure.config.input, data)
+                : data;
             const context: EventResolverContext<TIO, TPresence, InferDocLike<TCrdt>> = {
                 doc: this._crdtManager.doc,
                 others: this._usersManager.getOthers(),

--- a/packages/client/src/PluvClient.ts
+++ b/packages/client/src/PluvClient.ts
@@ -1,5 +1,5 @@
 import type { AbstractCrdtDocFactory, InferStorage, NoopCrdtDocFactory } from "@pluv/crdt";
-import type { InferIOCrdtKind, InputZodLike, IOLike, JsonObject } from "@pluv/types";
+import type { InferIOCrdtKind, IOLike, JsonObject, StandardSchemaV1 } from "@pluv/types";
 import { MAX_PRESENCE_SIZE_BYTES } from "./constants";
 import type { InferCallback } from "./infer";
 import { PluvProcedure } from "./PluvProcedure";
@@ -29,8 +29,8 @@ export type PluvClientOptions<
      * this if you control the server and have changed the limits there.
      */
     limits?: PluvClientLimits;
-    metadata?: InputZodLike<TMetadata>;
-    presence?: InputZodLike<TPresence>;
+    metadata?: StandardSchemaV1<unknown, TMetadata>;
+    presence?: StandardSchemaV1<unknown, TPresence>;
     publicKey?: PublicKey<TMetadata>;
     types: InferCallback<TIO>;
 } & (InferIOCrdtKind<TIO> extends NoopCrdtDocFactory
@@ -63,13 +63,13 @@ export class PluvClient<
     TCrdt extends InferIOCrdtKind<TIO> = InferIOCrdtKind<TIO>,
     TMetadata extends JsonObject = {},
 > {
-    public readonly metadata?: InputZodLike<TMetadata>;
+    public readonly metadata?: StandardSchemaV1<unknown, TMetadata>;
 
     private readonly _authEndpoint: AuthEndpoint<TMetadata>;
     private readonly _debug: boolean;
     private readonly _initialStorage?: TCrdt;
     private readonly _limits: PluvClientLimits;
-    private readonly _presence?: InputZodLike<TPresence>;
+    private readonly _presence?: StandardSchemaV1<unknown, TPresence>;
     private readonly _publicKey: PublicKey<TMetadata> | null = null;
     private readonly _rooms = new Map<string, PluvRoom<TIO, TMetadata, TPresence, TCrdt, any>>();
     private readonly _wsEndpoint: WsEndpoint<TMetadata> | undefined;

--- a/packages/client/src/PluvProcedure.ts
+++ b/packages/client/src/PluvProcedure.ts
@@ -1,5 +1,5 @@
 import type { AbstractCrdtDocFactory, InferDocLike } from "@pluv/crdt";
-import type { EventRecord, IOLike, InputZodLike, JsonObject, ProcedureLike } from "@pluv/types";
+import type { EventRecord, IOLike, JsonObject, ProcedureLike, StandardSchemaV1 } from "@pluv/types";
 import type { EventResolver, MergeEventRecords } from "./types";
 
 export interface PluvProcedureConfig<
@@ -10,7 +10,7 @@ export interface PluvProcedureConfig<
     TCrdt extends AbstractCrdtDocFactory<any, any>,
 > {
     broadcast?: EventResolver<TIO, TInput, TOutput, TPresence, InferDocLike<TCrdt>> | null;
-    input?: InputZodLike<TInput>;
+    input?: StandardSchemaV1<unknown, TInput>;
 }
 
 export class PluvProcedure<
@@ -28,7 +28,7 @@ export class PluvProcedure<
         TPresence,
         InferDocLike<TCrdt>
     > | null = null;
-    private _input: InputZodLike<TInput> | null = null;
+    private _input: StandardSchemaV1<unknown, TInput> | null = null;
 
     public get config(): ProcedureLike<TInput, TOutput>["config"] {
         return {
@@ -76,7 +76,7 @@ export class PluvProcedure<
     }
 
     public input<TData extends JsonObject>(
-        input: InputZodLike<TData>,
+        input: StandardSchemaV1<unknown, TData>,
     ): Omit<PluvProcedure<TIO, TData, {}, TPresence, TCrdt, TFilled | "input">, TFilled | "input"> {
         return new PluvProcedure<TIO, TData, {}, TPresence, TCrdt, TFilled | "input">({ input });
     }

--- a/packages/client/src/PluvRoom.ts
+++ b/packages/client/src/PluvRoom.ts
@@ -20,7 +20,6 @@ import type {
     InferIOAuthorizeUser,
     InferIOInput,
     InferIOOutput,
-    InputZodLike,
     JsonObject,
     MergeEvents,
     OptionalProps,
@@ -28,6 +27,7 @@ import type {
     OthersSubscriptionCallback,
     RoomEventListenerMap,
     RoomLike,
+    StandardSchemaV1,
     StateNotifierSubjects,
     StorageProxy,
     StorageRootSubscriptionCallback,
@@ -63,7 +63,7 @@ import type {
 import type { UsersManagerConfig } from "./UsersManager";
 import { UsersManager } from "./UsersManager";
 import { UsersNotifier } from "./UsersNotifier";
-import { debounce } from "./utils";
+import { debounce, parsePluvSchema } from "./utils";
 
 const ADD_TO_STORAGE_STATE_DEBOUNCE_MS = 1_000;
 const HEARTBEAT_INTERVAL_MS = 10_000;
@@ -191,7 +191,7 @@ export type RoomConfig<
         debug?: boolean | PluvRoomDebug<TIO>;
         limits: PluvClientLimits;
         onAuthorizationFail?: (error: Error) => void;
-        metadata?: InputZodLike<TMetadata>;
+        metadata?: StandardSchemaV1<unknown, TMetadata>;
         publicKey?: PublicKey<TMetadata>;
         reconnectTimeoutMs?: ReconnectTimeoutMs;
         router?: PluvRouter<TIO, TPresence, InferStorage<TCrdt>, TEvents>;
@@ -210,7 +210,7 @@ export class PluvRoom<
     readonly _endpoints: RoomEndpoints<TIO, TMetadata>;
 
     public readonly id: string;
-    public readonly metadata?: InputZodLike<TMetadata>;
+    public readonly metadata?: StandardSchemaV1<unknown, TMetadata>;
 
     private readonly _crdtManager: CrdtManager<TCrdt>;
     private readonly _crdtNotifier = new CrdtNotifier<InferStorage<TCrdt>>();
@@ -347,7 +347,9 @@ export class PluvRoom<
 
             if (!myself) return;
 
-            const parsed = procedure.config.input ? procedure.config.input.parse(data) : data;
+            const parsed = procedure.config.input
+                ? parsePluvSchema(procedure.config.input, data)
+                : data;
             const context: EventResolverContext<TIO, TPresence, InferDocLike<TCrdt>> = {
                 doc: this._crdtManager.doc,
                 others: this._usersManager.getOthers(),
@@ -1569,7 +1571,7 @@ export class PluvRoom<
     }
 
     private _setMetadata(metadata: TMetadata): TMetadata {
-        const parsed = this.metadata ? this.metadata.parse(metadata) : metadata;
+        const parsed = this.metadata ? parsePluvSchema(this.metadata, metadata) : metadata;
 
         this._lastMetadata = parsed;
 

--- a/packages/client/src/UsersManager.ts
+++ b/packages/client/src/UsersManager.ts
@@ -1,14 +1,14 @@
-import type { InputZodLike, IOLike, JsonObject, OptionalProps, UserInfo } from "@pluv/types";
+import type { IOLike, JsonObject, OptionalProps, StandardSchemaV1, UserInfo } from "@pluv/types";
 import { PLUV_PRESENCE_META_KEY } from "./constants";
 import type { PluvClientLimits } from "./types";
-import { pickBy } from "./utils";
+import { parsePluvSchema, pickBy } from "./utils";
 
 export type Presence = Record<string, unknown>;
 
 export type UsersManagerConfig<TPresence extends Record<string, any> = {}> = {
     initialPresence?: TPresence;
     limits: PluvClientLimits;
-    presence?: InputZodLike<TPresence>;
+    presence?: StandardSchemaV1<unknown, TPresence>;
 };
 
 export type AddConnectionResult<TIO extends IOLike, TPresence extends Record<string, any> = {}> = {
@@ -45,7 +45,7 @@ export class UsersManager<TIO extends IOLike, TPresence extends Record<string, a
      */
     private _myself: UserInfo<TIO, TPresence> | null = null;
     private _others = new Map<[clientId: string][0], UserInfo<TIO, TPresence>>();
-    private _presence: InputZodLike<TPresence> | null = null;
+    private _presence: StandardSchemaV1<unknown, TPresence> | null = null;
 
     constructor(config: UsersManagerConfig<TPresence>) {
         const { initialPresence, limits, presence = null } = config;
@@ -207,7 +207,7 @@ export class UsersManager<TIO extends IOLike, TPresence extends Record<string, a
             ...cleanedPresence,
             ...cleanedPatch,
         } as TPresence;
-        const validated = this._presence ? this._presence.parse(presence) : presence;
+        const validated = this._presence ? parsePluvSchema(this._presence, presence) : presence;
 
         /**
          * !HACK

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -18,6 +18,7 @@ export { infer } from "./infer";
 export type { InferCallback } from "./infer";
 export { MockedRoom } from "./MockedRoom";
 export type { MockedRoomConfig, MockedRoomEvents } from "./MockedRoom";
+export { parsePluvSchema } from "./utils";
 export { PluvClient } from "./PluvClient";
 export type { CreateRoomOptions, EnterRoomParams, PluvClientOptions } from "./PluvClient";
 export type { PluvProcedureConfig } from "./PluvProcedure";

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { debounce } from "./debounce";
 export { identity } from "./identity";
+export { parsePluvSchema } from "./parsePluvSchema";
 export { pickBy } from "./pickBy";

--- a/packages/client/src/utils/parsePluvSchema.ts
+++ b/packages/client/src/utils/parsePluvSchema.ts
@@ -1,0 +1,20 @@
+import type { JsonObject, StandardSchemaV1 } from "@pluv/types";
+
+export function parsePluvSchema<TData extends JsonObject>(
+    schema: StandardSchemaV1<unknown, TData>,
+    data: unknown,
+): TData {
+    const result = schema["~standard"].validate(data);
+
+    if (result instanceof Promise) {
+        throw new Error("Async schemas are not supported. Schema validate() must be synchronous.");
+    }
+
+    if (result.issues) {
+        const message = result.issues[0]?.message ?? "Invalid input";
+
+        throw new Error(message);
+    }
+
+    return result.value as TData;
+}

--- a/packages/io/src/IORoom.ts
+++ b/packages/io/src/IORoom.ts
@@ -47,7 +47,7 @@ import type {
     WebSocketSession,
     WebSocketType,
 } from "./types";
-import { oneLine } from "./utils";
+import { oneLine, parsePluvSchema } from "./utils";
 
 type BroadcastMessage<TIO extends IORoom<any, any, any, any, any>> =
     | InferEventMessage<InferIOInput<TIO>>
@@ -640,7 +640,7 @@ export class IORoom<
         }
 
         try {
-            return ioAuthorize.user.parse(payload.user);
+            return parsePluvSchema(ioAuthorize.user, payload.user);
         } catch {
             this._logDebug(`${colors.blue("Token fails validation:")} ${token}`);
 
@@ -748,7 +748,9 @@ export class IORoom<
 
         if (!procedure) return message.data;
 
-        return procedure.config.input ? procedure.config.input.parse(message.data) : message.data;
+        return procedure.config.input
+            ? parsePluvSchema(procedure.config.input, message.data)
+            : message.data;
     }
 
     private _getSession(webSocket: WebSocketType<TPlatform>): WebSocketSession<TAuthorize> {

--- a/packages/io/src/PluvIO.ts
+++ b/packages/io/src/PluvIO.ts
@@ -24,7 +24,7 @@ import type {
     PluvIORouter,
     ResolvedPluvIOAuthorize,
 } from "./types";
-import { oneLine } from "./utils";
+import { oneLine, parsePluvSchema } from "./utils";
 import { __PLUV_VERSION } from "./version";
 
 export type PluvIOConfig<
@@ -144,7 +144,7 @@ export class PluvIO<
     ): Promise<string> {
         const ioAuthorize = this._getIOAuthorize(params);
         const user = params.user as BaseUser;
-        const parsed = ioAuthorize.user.parse(user);
+        const parsed = parsePluvSchema(ioAuthorize.user, user);
 
         if (!!this._limits.userIdMaxLength && user.id.length > this._limits.userIdMaxLength) {
             throw new Error(oneLine`

--- a/packages/io/src/PluvProcedure.ts
+++ b/packages/io/src/PluvProcedure.ts
@@ -1,9 +1,9 @@
 import type {
     EventRecord,
     IOAuthorize,
-    InputZodLike,
     JsonObject,
     ProcedureLike,
+    StandardSchemaV1,
 } from "@pluv/types";
 import type { AbstractPlatform, InferInitContextType } from "./AbstractPlatform";
 import type { EventResolver, EventResolverKind, MergeEventRecords } from "./types";
@@ -23,7 +23,7 @@ export interface PluvProcedureConfig<
         TInput,
         Partial<TOutput>
     > | null;
-    input?: InputZodLike<TInput>;
+    input?: StandardSchemaV1<unknown, TInput>;
     self?: EventResolver<"self", TPlatform, TAuthorize, TContext, TInput, Partial<TOutput>> | null;
     sync?: EventResolver<"sync", TPlatform, TAuthorize, TContext, TInput, Partial<TOutput>> | null;
 }
@@ -44,7 +44,7 @@ export class PluvProcedure<
         TInput,
         Partial<TOutput>
     > | null = null;
-    private _input: InputZodLike<TInput> | null = null;
+    private _input: StandardSchemaV1<unknown, TInput> | null = null;
     private _self: EventResolver<
         "self",
         TPlatform,
@@ -114,7 +114,7 @@ export class PluvProcedure<
     }
 
     public input<TData extends JsonObject>(
-        input: InputZodLike<TData>,
+        input: StandardSchemaV1<unknown, TData>,
     ): Omit<
         PluvProcedure<TPlatform, TAuthorize, TContext, TData, {}, TFilled | "input">,
         TFilled | "input"

--- a/packages/io/src/index.ts
+++ b/packages/io/src/index.ts
@@ -7,11 +7,12 @@ export type {
     EventRecord,
     InferIOAuthorize,
     InferIOAuthorizeUser,
-    InputZodLike,
     IOAuthorize,
     IOEventMessage,
     ProcedureLike,
+    StandardSchemaV1,
 } from "@pluv/types";
+export { parsePluvSchema } from "./utils";
 export { AbstractPersistence } from "./AbstractPersistence";
 export { AbstractPlatform } from "./AbstractPlatform";
 export type {

--- a/packages/io/src/types.ts
+++ b/packages/io/src/types.ts
@@ -8,12 +8,12 @@ import type {
     InferEventMessage,
     InferEventsOutput,
     InferIOAuthorizeUser,
-    InputZodLike,
     JsonObject,
     Maybe,
     MaybePromise,
     UndefinedProps,
 } from "@pluv/types";
+import type { StandardSchemaV1 } from "@pluv/types";
 import type {
     AbstractPlatform,
     InferInitContextType,
@@ -139,7 +139,7 @@ export interface PlatformConfig {
 export type ResolvedPluvIOAuthorize<
     TPlatform extends AbstractPlatform<any, any, any, any>,
     TUser extends BaseUser = any,
-> = { user: InputZodLike<TUser> } & UndefinedProps<
+> = { user: StandardSchemaV1<unknown, TUser> } & UndefinedProps<
     { secret?: string },
     Exclude<"secret", InferPlatformAuthorizeProperties<TPlatform>>
 >;

--- a/packages/io/src/utils/index.ts
+++ b/packages/io/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { oneLine } from "./oneLine";
+export { parsePluvSchema } from "./parsePluvSchema";
 export { pickBy } from "./pickBy";

--- a/packages/io/src/utils/parsePluvSchema.ts
+++ b/packages/io/src/utils/parsePluvSchema.ts
@@ -1,0 +1,20 @@
+import type { JsonObject, StandardSchemaV1 } from "@pluv/types";
+
+export function parsePluvSchema<TData extends JsonObject>(
+    schema: StandardSchemaV1<unknown, TData>,
+    data: unknown,
+): TData {
+    const result = schema["~standard"].validate(data);
+
+    if (result instanceof Promise) {
+        throw new Error("Async schemas are not supported. Schema validate() must be synchronous.");
+    }
+
+    if (result.issues) {
+        const message = result.issues[0]?.message ?? "Invalid input";
+
+        throw new Error(message);
+    }
+
+    return result.value as TData;
+}

--- a/packages/platform-pluv/src/PluvPlatform.ts
+++ b/packages/platform-pluv/src/PluvPlatform.ts
@@ -8,7 +8,7 @@ import type {
     PluvContext,
     WebSocketSerializedState,
 } from "@pluv/io";
-import { AbstractPlatform } from "@pluv/io";
+import { AbstractPlatform, parsePluvSchema } from "@pluv/io";
 import type { MaybePromise } from "@pluv/types";
 import stringify from "fast-json-stable-stringify";
 import type { Context } from "hono";
@@ -95,7 +95,7 @@ export class PluvPlatform<
     private readonly _webhookSecret?: WebhookSecret;
 
     public _createToken = async (params: JWTEncodeParams<any, any>): Promise<string> => {
-        const parsed = params.authorize.user.parse(params.user);
+        const parsed = parsePluvSchema(params.authorize.user, params.user);
 
         const [endpoints, publicKey, secretKey] = await Promise.all([
             typeof this._endpoints === "object" ? this._endpoints : this._endpoints(),

--- a/packages/platform-pluv/src/types.ts
+++ b/packages/platform-pluv/src/types.ts
@@ -6,7 +6,7 @@ import type {
     IOUserConnectedEvent,
     IOUserDisconnectedEvent,
 } from "@pluv/io";
-import type { InputZodLike } from "@pluv/types";
+import type { StandardSchemaV1 } from "@pluv/types";
 import type { z } from "zod";
 import type { PluvPlatform } from "./PluvPlatform";
 import type {
@@ -36,14 +36,14 @@ export type PluvIOListeners<
     onUserConnected: (
         event: IOUserConnectedEvent<
             PluvPlatform<TContext>,
-            { user: InputZodLike<TUser> },
+            { user: StandardSchemaV1<unknown, TUser> },
             TContext
         >,
     ) => void;
     onUserDisconnected: (
         event: IOUserDisconnectedEvent<
             PluvPlatform<TContext>,
-            { user: InputZodLike<TUser> },
+            { user: StandardSchemaV1<unknown, TUser> },
             TContext
         >,
     ) => void;

--- a/packages/react/src/createBundle.tsx
+++ b/packages/react/src/createBundle.tsx
@@ -10,7 +10,7 @@ import type {
     UserInfo,
     WebSocketConnection,
 } from "@pluv/client";
-import { MockedRoom } from "@pluv/client";
+import { MockedRoom, parsePluvSchema } from "@pluv/client";
 import type { InferCrdtJson, InferDoc, InferStorage } from "@pluv/crdt";
 import type {
     Id,
@@ -176,7 +176,7 @@ export const createBundle = <
                     typeof metadata === "function" ? metadata() : metadata,
                 );
 
-                return !!room.metadata ? room.metadata.parse(resolved) : resolved;
+                return !!room.metadata ? parsePluvSchema(room.metadata, resolved) : resolved;
             });
 
             useEffect(() => {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -34,6 +34,7 @@
         "typescript": "^7.0.2"
     },
     "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "wonka": "^6.3.6"
     },
     "exports": {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,6 +18,7 @@ export type {
     UndefinedProps,
 } from "./general";
 export { ConnectionState, StorageState } from "./pluv";
+export type { StandardSchemaV1 } from "@standard-schema/spec";
 export type {
     BaseClientEventRecord,
     BaseClientMessage,
@@ -49,7 +50,6 @@ export type {
     InferIOOutput,
     InferIOProcedureInput,
     InferIOProcedureOutput,
-    InputZodLike,
     IOAuthorize,
     IOAuthorizeEventMessage,
     IOEventMessage,

--- a/packages/types/src/pluv/shared.ts
+++ b/packages/types/src/pluv/shared.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { Id, JsonObject, MaybePromise, UnionToIntersection } from "../general";
 import { CrdtLibraryType } from "./crdt";
 
@@ -87,15 +88,11 @@ export type GetEventMessage<
 
 export type InferIOAuthorize<TIO extends IOLike<any, any, any>> =
     TIO extends IOLike<infer IAuthorize, any, any>
-        ? { user: InputZodLike<InferIOAuthorizeUser<IAuthorize>> }
+        ? { user: StandardSchemaV1<unknown, InferIOAuthorizeUser<IAuthorize>> }
         : never;
 
 export type InferIOAuthorizeUser<TAuthorize extends IOAuthorize<any, any>> =
     TAuthorize extends IOAuthorize<infer IUser, any> ? IUser : never;
-
-export type InputZodLike<TData extends JsonObject> = {
-    parse: (data: unknown) => TData;
-} & ({ _input: TData } | { _zod: { input: TData } });
 
 export type IOAuthorize<
     TUser extends BaseUser = any,
@@ -103,11 +100,11 @@ export type IOAuthorize<
 > =
     | {
           secret?: string;
-          user: InputZodLike<TUser>;
+          user: StandardSchemaV1<unknown, TUser>;
       }
     | ((context: TContext) => {
           secret?: string;
-          user: InputZodLike<TUser>;
+          user: StandardSchemaV1<unknown, TUser>;
       });
 
 export type IOAuthorizeEventMessage<TIO extends IOLike> = {
@@ -123,7 +120,7 @@ export type ProcedureLike<
         broadcast?:
             | ((data: TInput, ...args: any[]) => MaybePromise<Partial<TOutput> | void>)
             | null;
-        input?: InputZodLike<TInput> | null;
+        input?: StandardSchemaV1<unknown, TInput> | null;
         resolver: (data: TInput, ...args: any[]) => MaybePromise<TOutput>;
         self?: ((data: TInput, ...args: any[]) => MaybePromise<Partial<TOutput> | void>) | null;
         sync?: ((data: TInput, ...args: any[]) => MaybePromise<Partial<TOutput> | void>) | null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,6 +623,9 @@ importers:
 
   packages/types:
     dependencies:
+      '@standard-schema/spec':
+        specifier: ^1.1.0
+        version: 1.1.0
       wonka:
         specifier: ^6.3.6
         version: 6.3.6

--- a/tests/unit/src/IORoom.procedureError.test.ts
+++ b/tests/unit/src/IORoom.procedureError.test.ts
@@ -67,18 +67,23 @@ describe("IORoom procedure errors", () => {
             router: io.router({
                 echo: io.procedure
                     .input({
-                        parse: (data: unknown) => {
-                            if (
-                                typeof data !== "object" ||
-                                data === null ||
-                                typeof (data as { message?: unknown }).message !== "string"
-                            ) {
-                                throw new Error("Expected { message: string }");
-                            }
+                        "~standard": {
+                            version: 1,
+                            vendor: "test",
+                            validate: (data: unknown) => {
+                                if (
+                                    typeof data !== "object" ||
+                                    data === null ||
+                                    typeof (data as { message?: unknown }).message !== "string"
+                                ) {
+                                    return {
+                                        issues: [{ message: "Expected { message: string }" }],
+                                    };
+                                }
 
-                            return data as { message: string };
+                                return { value: data as { message: string } };
+                            },
                         },
-                        _input: { message: "" },
                     })
                     .broadcast(({ message }) => ({ echoed: { message } })),
             }),


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/pluv-io/pluv/blob/main/CONTRIBUTING.md) (updated 2023-01-05).
- [x] The PR title follows the [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [ ] I have added or updated the tests related to the changes made.

---

## Changelog

Accept any Standard Schema validator for authorize, presence, metadata, and procedure inputs.

Zod still works as before on recent versions (3.24+/4). You can also use Valibot, ArkType, or other Standard Schema–compatible libraries. The old `InputZodLike` duck type (`{ parse, _input }`) is removed — schemas must expose `~standard.validate`.
